### PR TITLE
Modular plugin restructure: Claude + Codex, cross-platform, robustness pass

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "powerplatform-core",
+  "interface": {
+    "displayName": "Power Platform Core"
+  },
+  "plugins": [
+    {
+      "name": "powerplatform-core",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "powerplatform-core",
+  "owner": {
+    "name": "Satrio Tsubasa"
+  },
+  "description": "Power Platform / Dataverse coding-agent skills.",
+  "plugins": [
+    {
+      "name": "powerplatform-core",
+      "source": "./",
+      "description": "Coding-agent skill for Microsoft Power Platform and Dataverse development.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Satrio Tsubasa"
+      },
+      "homepage": "https://github.com/satriotsubasa/PowerPlatform-Core",
+      "license": "Apache-2.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "powerplatform-core",
+  "version": "1.0.0",
+  "description": "Coding-agent skill for Microsoft Power Platform and Dataverse development. Read a repo, understand model-driven app and solution structure, choose the right development surface, and safely build, validate, and deliver source-controlled changes: plug-ins, PCF controls, web resources, form and ribbon metadata, solution-aware flows, Dataverse schema, configuration data, custom APIs, and solution ALM.",
+  "author": {
+    "name": "Satrio Tsubasa"
+  },
+  "homepage": "https://github.com/satriotsubasa/PowerPlatform-Core",
+  "repository": "https://github.com/satriotsubasa/PowerPlatform-Core",
+  "license": "Apache-2.0",
+  "keywords": [
+    "power-platform",
+    "dataverse",
+    "power-apps",
+    "power-automate",
+    "pcf",
+    "plugins",
+    "dynamics-365",
+    "alm"
+  ],
+  "skills": "./skills/"
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "powerplatform-core",
+  "version": "1.0.0",
+  "description": "Coding-agent skill for Microsoft Power Platform and Dataverse development. Read a repo, understand model-driven app and solution structure, choose the right development surface, and safely build, validate, and deliver source-controlled changes (plug-ins, PCF controls, web resources, form and ribbon metadata, solution-aware flows, Dataverse schema, configuration data, custom APIs, solution ALM) with a required live-mutation preflight.",
+  "author": {
+    "name": "Satrio Tsubasa",
+    "url": "https://github.com/satriotsubasa/PowerPlatform-Core"
+  },
+  "homepage": "https://github.com/satriotsubasa/PowerPlatform-Core",
+  "repository": "https://github.com/satriotsubasa/PowerPlatform-Core",
+  "license": "Apache-2.0",
+  "keywords": [
+    "power-platform",
+    "dataverse",
+    "power-apps",
+    "power-automate",
+    "pcf",
+    "plugins",
+    "dynamics-365",
+    "alm"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Power Platform Core",
+    "shortDescription": "Coding-agent skill for Microsoft Power Platform and Dataverse development",
+    "longDescription": "Generic, code-first skill for Microsoft Power Platform and Dataverse. Discovers repo context, picks the right development surface (metadata, client script, plug-in, custom API, flow, PCF, or solution ALM), applies repo-backed changes, and delivers them through safe, targeted paths behind a mandatory live-mutation preflight. Works without assuming any one house repo convention.",
+    "category": "Coding",
+    "brandColor": "#149CA1",
+    "composerIcon": "./assets/power-platform-uploaded-exact.png",
+    "logo": "./assets/power-platform-uploaded-exact.png",
+    "defaultPrompt": [
+      "Read this repo, understand the Power Platform and Dataverse solution structure, and tell me the safest way to deliver my change.",
+      "Build and deploy this plug-in / PCF / flow change with the required live-mutation preflight."
+    ]
+  }
+}

--- a/CODEX_HANDOFF.md
+++ b/CODEX_HANDOFF.md
@@ -1,6 +1,6 @@
 # CODEX Handoff
 
-Last updated: 2026-04-27
+Last updated: 2026-06-11
 
 ## Purpose
 
@@ -41,6 +41,17 @@ Clean state after production-ready rename and scrub:
 - GitHub: `satriotsubasa/PowerPlatform-Core`
 - All company-specific references removed from test fixtures, templates, and documentation
 - Core overlay discovery supports any extension via `"extends": "powerplatform-core"` in overlay `skill-package.json`
+
+## Plugin & Multi-Agent Restructure (branch `feature/modular-plugin-multiagent`)
+
+Active work converting the monolith into a multi-agent plugin. Not yet merged to `main`.
+
+- Packaged as a plugin installable on both Claude Code (`.claude-plugin/`) and OpenAI Codex (`.codex-plugin/` + `.agents/plugins/marketplace.json`) from one shared source; both manifests point at `skills/`.
+- The monolithic guidance is decomposed into 11 modular skills under `skills/` (orchestrator `powerplatform-core` + 10 domain skills). The shared toolchain (`scripts/`, `tools/`, `references/`) stays at the plugin root, resolved via `$CLAUDE_PLUGIN_ROOT` / `$CODEX_PLUGIN_ROOT`. The root `SKILL.md` is now a thin plugin-aware pointer.
+- Cross-platform: `CodexPowerPlatform.DataverseOps` multi-targets `net8.0` + `net8.0-windows`; the WAM broker is Windows-only (runtime-guarded), macOS/Linux use device-code sign-in. The WPF `AuthDialog` stays Windows-only.
+- Phase 1 robustness pass landed: security-role paging fix, requirement-spec step-type fix, FetchXML escaping, Windows exec resolution in `push_code_app`, timeouts/leak-safety, FormXml DTD hardening, plus regression tests. `verify_repo.py` now also validates skill structure and skips Windows-only .NET builds off-Windows.
+- Note: the role `issytemgenerated` filter is the real (misspelled) Dataverse logical name — verified against MS docs; do not "fix" it.
+- Remaining: finalize install/migration docs; merge to `main`.
 
 ## Architecture State
 

--- a/README.md
+++ b/README.md
@@ -1,275 +1,141 @@
 # PowerPlatform-Core
 
-PowerPlatform-Core is a coding-agent skill for Microsoft Power Platform and Dataverse development. Type or ask for `$powerplatform-core` in Codex when you want an agent to read a repo, understand model-driven app and solution structure, and safely build, validate, and deliver source-controlled changes such as plug-ins, PCF controls, web resources, form metadata, RibbonDiffXml, solution-aware flows, Dataverse schema, and configuration data.
-
-It turns Power Platform work into a repo-first development workflow: discover the project shape, choose the right implementation surface, make reviewable code or metadata changes, run a live mutation preflight, and deploy only through an approved targeted path unless the user explicitly accepts a broader blast radius.
-
-This repository is the public, repo-agnostic base skill. It is meant to work across unfamiliar Power Platform and Dataverse repos, including:
-
-- layered code-centric repos
-- unpacked-solution repos
-- mixed or ambiguous repos
-- sparse repos with little or no existing structure
-
-Opinionated house conventions belong in overlay repos, not here.
-
-## How It Works
-
-1. It can discover repo context from `.sln` files, `WebResources/`, `Dataverse/`, `*.Plugins`, `*.Data`, PCF projects, solution XML, project profiles, and PAC context when needed.
-2. It selects the development surface: client script, plug-in, custom API, PCF, form metadata, RibbonDiffXml, flow, Dataverse schema, config data, or solution ALM.
-3. It favors source-controlled edits and deterministic helpers over maker-portal memory or browser automation.
-4. It runs a live mutation preflight that names the environment, PAC profile, target solution, exact components, delivery primitive, artifact source, blast radius, timeout, and rollback path.
-5. It validates and deploys through approved targeted paths first, such as web resource sync, plug-in push, form/ribbon patch helpers, PCF wrapper deployment, flow update helpers, or keyed data upsert.
-
-## What Core Owns
-
-Core is the maintenance home for:
-
-- generic skill contract in `SKILL.md`
-- generic references in `references/`
-- generic helper scripts in `scripts/`
-- generic tools in `tools/`
-- generic regression tests in `tests/`
-- generic packaging and install behavior
-
-Current overlay relationship:
-
-- `powerplatform-core` installs directly from this repo
-- Overlay extensions install as separate layers on top of this runtime
-- House-style conventions are overlay-owned and are not shipped as Core references
-
-That overlay note is informational only. Core remains a standalone, generic skill for broader Power Platform use.
-
-## Current Capabilities
-
-Core currently supports:
-
-- repo discovery and context inference through `scripts/discover_context.py`
-- auth gating and selected-solution confirmation through `scripts/auth_context.py`
-- Dataverse row create, update, and upsert
-- metadata creation and update helpers for tables, fields, lookups, forms, views, icons, and solution component placement
-- security role inspect, create, and update helpers with solution-aware role privilege sync
-- environment variable inspect and live value-set helpers
-- client customization helpers for form-event registration, web resource sync, and PCF binding
-- server-extension helpers for custom APIs, first-time plug-in registration, and repeatable plug-in push
-- PCF scaffolding, versioning, packaging, and deployment
-- solution-aware cloud flow inspect, lint, create, update, signed HTTP trigger URL retrieval, and hardening review
-- document-generation inspection and planning
-- solution deployment and delivery validation
-- coordinated multi-step execution through `scripts/apply_requirement_spec.py`
-- Power Apps Code App build and push via `scripts/push_code_app.py`, with automatic `power.config.json` detection in `scripts/discover_context.py`
-
-For the fuller maintainer-oriented capability breakdown that used to live in the long README, see [docs/capability-matrix.md](docs/capability-matrix.md).
-
-Core guidance now also explicitly covers:
-
-- choosing the right implementation surface through [references/execution-surface-guide.md](references/execution-surface-guide.md)
-- command-bar and RibbonDiffXml safety: use web-resource-only deploys for existing command logic, reserve `patch_form_ribbon.py` for form-level metadata, and route new entity commands/buttons/rules through fresh package recovery with version bump and read-back verification
-- completion evidence and partial-failure recovery through [references/verification-and-recovery.md](references/verification-and-recovery.md)
-- immutable stable keys, source-system-qualified provenance, and honest dry-run boundaries in data operations
-- explicit deployment closeout that distinguishes repo-ready from environment-updated state
-- deployment preflight, timeout budgets, and fast-fail manual fallback through `deploymentDefaults` in the project profile and `scripts/apply_requirement_spec.py`
-
-## Design Principles
-
-- Keep the skill generic. Do not hardcode one tenant, one publisher prefix, one namespace pattern, or one repo layout.
-- Keep presentation and configuration work in metadata when possible.
-- For executable logic, prefer code-managed surfaces. Use client script for form-scoped behavior and plug-ins or custom APIs for shared server-side behavior.
-- Do not choose Dataverse Business Rules as an implementation surface in this skill.
-- Prefer repo-backed and headless-first execution over browser automation.
-- Surface PAC-profile versus requested-target mismatches before live work instead of silently assuming the currently selected PAC environment is correct.
-- Keep changes solution-scoped.
-- Ask before delete, import, publish, register, push, or upgrade.
-- Treat project context as runtime input, not fixed skill configuration.
-- Optimize user waiting time, not just eventual task completion. Fail fast when preflight says the surface is manual-only, unsupported, or timed out.
-
-## Repo Layout
-
-Important top-level paths:
-
-- `SKILL.md`: skill contract and workflow
-- `agents/`: UI metadata
-- `references/`: generic working guidance
-- `scripts/`: Python helper entry points
-- `tools/`: shared .NET tools
-- `tests/`: repo-local regression coverage
-- `docs/core-overlay-architecture.md`: Core vs overlay ownership
-- `verify_repo.py`: canonical local verification entry point
-
-## Verification
-
-Canonical local verification:
-
-```powershell
-python .\verify_repo.py
-```
-
-That command currently runs:
-
-- Python syntax checks across `scripts/`, `tests/`, and `verify_repo.py`
-- `python -m unittest discover -s tests -v`
-- `dotnet build` for both tool projects
-- `quick_validate.py` when the local Codex `skill-creator` validator is available
-
-Useful options:
-
-```powershell
-python .\verify_repo.py --skip-dotnet
-python .\verify_repo.py --skip-quick-validate
-```
-
-The unit suite now includes lightweight acceptance scenarios for these representative repo shapes:
-
-- layered hybrid repos
-- unpacked-solution-first repos
-- ambiguous mixed repos
-- tool-only repos
-- sparse repos with no established structure
-
-## Installing The Skill
-
-Local install:
-
-```powershell
-.\install-skill.ps1
-```
-
-Local update:
-
-```powershell
-.\update-skill.ps1
-```
-
-GitHub-based install:
-
-```powershell
-.\install-skill.ps1 -Source GitHub
-.\update-skill.ps1 -Source GitHub
-```
-
-Installed runtime payload includes only:
-
-- `SKILL.md`
-- `agents/`
-- `assets/`
-- `references/`
-- `scripts/`
-- `tools/`
-
-Repo-only files such as `README.md`, `CODEX_HANDOFF.md`, `tests/`, and repo maintenance scripts stay in the source repo and are not copied into the installed skill.
-
-## Using The Skill
-
-Example prompts:
-
-```text
-Use $powerplatform-core to inspect this repo and infer the likely Dataverse solution, source areas, and plug-in project.
-Use $powerplatform-core to create a new Dataverse table and expose it in the target model-driven app.
-Use $powerplatform-core to update a form script, sync the web resource, and register the handler.
-Use $powerplatform-core to package and deploy a PCF control from this repo.
-Use $powerplatform-core to execute this requirement spec end to end.
-```
-
-When the repo is unfamiliar, start by running:
-
-```powershell
-python .\scripts\discover_context.py --path .
-```
-
-For exact helper arguments, use each script's CLI help:
-
-```powershell
-python .\scripts\deploy_solution.py --help
-python .\scripts\deploy_pcf.py --help
-python .\scripts\upsert_data.py --help
-python .\scripts\get_flow_trigger_url.py --help
-```
-
-## Standalone vs. Extension Mode
-
-PowerPlatform-Core can be used in two ways depending on your needs.
-
-### Standalone (Core only)
-
-Install this skill and use it directly against any Power Platform or Dataverse repo. No other skill is required. This is the recommended starting point for most users.
-
-```powershell
-.\install-skill.ps1
-```
-
-Then invoke it in Codex:
-
-```text
-Use $powerplatform-core to inspect this repo and infer the solution structure.
-```
-
-Core is generic by design — it works across unfamiliar repos, mixed layouts, and varying namespace conventions without any configuration.
-
-### With an Overlay Extension
-
-An overlay extension is a separate skill that layers house-style conventions, project-specific references, and team-specific defaults on top of Core. The overlay is installed as its own skill and replaces the `$powerplatform-core` prompt with its own skill token.
-
-If you are working in a repo that has an accompanying overlay skill:
-
-1. Install Core first:
-   ```powershell
-   # From this repo
-   .\install-skill.ps1
-   ```
-
-2. Install the overlay skill from its own repo:
-   ```powershell
-   # From the overlay repo
-   .\install-skill.ps1
-   ```
-
-3. Use the overlay skill token instead of `$powerplatform-core`:
-   ```text
-   Use the overlay skill token to inspect this repo.
-   ```
-
-The overlay skill bundles Core's runtime files together with its own files into a single merged skill. Core's generic capabilities are fully available through the overlay — you do not need to invoke both.
-
-### How to tell which one to use
-
-| Situation | Use |
-|-----------|-----|
-| Any generic Power Platform / Dataverse repo | `$powerplatform-core` standalone |
-| Repo that follows a specific team's house conventions | That team's overlay skill |
-| Unfamiliar repo, no overlay available | `$powerplatform-core` standalone |
-| Building your own overlay extension | See [docs/core-overlay-architecture.md](docs/core-overlay-architecture.md) |
+**A code-first coding-agent plugin that turns Microsoft Power Platform & Dataverse work into a safe, source-controlled, repo-first workflow.**
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-d97757.svg)](#install)
+[![OpenAI Codex](https://img.shields.io/badge/OpenAI%20Codex-plugin-412991.svg)](#install)
+[![Cross-platform](https://img.shields.io/badge/Cross--platform-Windows%20%C2%B7%20macOS%20%C2%B7%20Linux-2ea44f.svg)](#requirements)
+[![Built with](https://img.shields.io/badge/Built%20with-Python%20%C2%B7%20.NET%208-149CA1.svg)](#how-its-built)
 
 ---
 
-## Current Boundaries
+## What & why
 
-Core intentionally does not:
+Power Platform changes are easy to make and hard to make *safely* — a single stale ZIP or an accidental whole-solution import can quietly overwrite other people's work. PowerPlatform-Core gives a coding agent the judgment to avoid that: it reads your repo, understands your model-driven app and solution structure, picks the right development surface, makes reviewable source-controlled edits, and ships them through the narrowest delivery path behind a **mandatory live-mutation preflight**.
 
-- assume one house repo structure
-- assume one namespace style
-- ship overlay-owned house-style references
-- imply that `scripts/upsert_data.py` supports a generic dry-run mode when it does not
-- default to browser automation when repo-backed or headless paths exist
+It is deliberately generic. It works across unfamiliar repos — layered code-centric, unpacked-solution, mixed, or near-empty — without assuming any one team's house convention, publisher prefix, or folder layout.
 
-Some capabilities still remain partly workflow-driven rather than fully helper-packaged, especially:
+## Highlights
 
-- bespoke XML surgery
-- highly repo-specific architecture decisions
-- environment-specific acceptance testing
-- document-template authoring that depends on one team's conventions
+- 🧭 **11 modular skills that trigger precisely** — an orchestrator routes each task (schema, data, flows, plug-ins, PCF, code apps, ALM, security, docs, connectors) to exactly the right specialist.
+- 🛡️ **Safe by default** — every live mutation passes a preflight gate; stale artifacts are blocked; targeted delivery is preferred over whole-solution imports.
+- ⌨️ **Headless / code-first** — repo edits, SDK/Web API, solution files, and the `pac` CLI come first; browser automation is an opt-in last resort.
+- 🤝 **Multi-agent** — one shared source installs as both a **Claude Code** plugin and an **OpenAI Codex** plugin.
+- 🌐 **Cross-platform live path** — the runtime works on Windows *and* macOS/Linux (WAM broker sign-in on Windows, device-code flow elsewhere).
 
-## Maintainer Notes
+## Install
 
-- Make generic changes here first.
-- Keep overlay-specific prompts, examples, and conventions out of Core.
-- If a repo already has a safe deploy wrapper, Core may use it, but Core should not prescribe one project-specific wrapper shape as a default.
-- Keep `README.md` focused on overview, install, verification, and maintenance boundaries.
-- Keep `CODEX_HANDOFF.md` focused on current repo state and in-flight work, not static capability manuals.
+PowerPlatform-Core installs from one shared source into either agent.
 
-## Next Recommended Work
+### Claude Code
 
-The only current tracked follow-on is issue `#19`:
+```text
+/plugin marketplace add satriotsubasa/PowerPlatform-Core
+/plugin install powerplatform-core@powerplatform-core
+```
 
-- optional Azure control-plane reference as a secondary path
+> The marketplace commands above resolve once the plugin is on the repo's default branch. To try a **local checkout** instead, launch with `claude --plugin-dir "<path-to-repo>"`, or run `/plugin marketplace add "<path-to-repo>"` pointed at your clone.
 
-That remains explicitly optional and deferred behind the generic Core acceptance and verification foundation.
+### OpenAI Codex
+
+```text
+codex plugin marketplace add satriotsubasa/PowerPlatform-Core
+codex plugin add powerplatform-core
+```
+
+> The exact subcommand can vary by Codex version — confirm with `codex plugin --help` if either line is rejected.
+
+### Requirements
+
+The skills are code-first, so the live path needs a small local toolchain:
+
+| Tool | Why |
+| --- | --- |
+| **Python 3.10+** | Runs the helper scripts that drive every live operation. |
+| **.NET 8 SDK** | Builds and runs the shared `DataverseOps` execution tool (and plug-in projects). |
+| **Node.js** | Required for PCF controls and Power Apps Code Apps (`npm` / `npx`). |
+| **Microsoft Power Platform CLI (`pac`)** | Authentication, solution, and deployment operations. |
+
+Interactive sign-in is platform-aware: on **Windows** it uses the WAM broker; on **macOS/Linux** it falls back to the **device-code flow** (the tool prints a code to complete in a browser).
+
+## The skills
+
+Start with the **orchestrator** — `powerplatform-core` — which discovers repo context, chooses the development surface, enforces the safety rules, and routes to the right specialist below. You rarely need to name a skill yourself; the agent picks one from your prompt.
+
+| Skill | What it does |
+| --- | --- |
+| **`powerplatform-core`** | 🧭 Orchestrator. Discovers repo context, picks the surface, enforces the live-mutation preflight, and routes to the right domain skill. |
+| **`dataverse-schema`** | Tables, columns, lookups, choices, alternate keys, forms, views, the form ribbon (RibbonDiffXml), and table icons — plus up-front schema/query design. |
+| **`data-operations`** | Row create / update / upsert, config-data seeding and sync, and query design across OData, FetchXML, and Power Automate "List rows". |
+| **`power-automate-flows`** | Solution-aware cloud flows: create, update, inspect, lint, connector & hardening review, and HTTP-trigger callback URL resolution. |
+| **`plugins-server-extensions`** | C# plug-ins and custom APIs: headless registration, repeatable build-and-push, step inspection, and step-state reconciliation. |
+| **`pcf-and-web-resources`** | PCF controls, web resources, client form scripts, and Power Fx review — scaffold, version, build, deploy, and bind. |
+| **`code-apps`** | Power Apps Code Apps (the pro-code Vite + `@microsoft/power-apps` SPA model): scaffold, add data sources, build, and push. |
+| **`solution-alm-delivery`** | The safety-critical delivery skill: pack/import/deploy, component placement, versioning, patch/merge/upgrade planning, and standards review. |
+| **`security-roles`** | Inspect, create, and update Dataverse security roles and privilege sets as reviewable, solution-aware desired state. |
+| **`document-generation`** | Word Template document generation: inventory content controls, map placeholders, and plan template-aware changes. |
+| **`custom-connectors`** | Design custom connectors and integration wrappers — auth shape, operation inventory, and direct-connector vs. Azure-facade recommendation. |
+
+## Quickstart
+
+Just describe the outcome you want. The agent discovers context, opens the matching skill, and runs the preflight before any live change.
+
+```text
+Add a Dataverse table for "Service Visit" and surface it in the target model-driven app.
+```
+> Routes to `dataverse-schema`, designs the table/columns, then checks solution and app exposure — preflight before any write.
+
+```text
+Package and deploy this PCF control from the repo.
+```
+> Routes to `pcf-and-web-resources`, syncs the manifest + wrapper versions, builds, and deploys via the targeted path — not a whole-solution import.
+
+```text
+Harden this cloud flow and resolve its HTTP trigger URL.
+```
+> Routes to `power-automate-flows`, runs the hardening review, patches only the changed `workflow` properties, and resolves the signed callback URL — preflight before the update.
+
+## Safety by default
+
+The thing that makes this plugin different from "an agent with `pac` access" is its refusal to do the dangerous-but-easy thing:
+
+- **Mandatory live-mutation preflight.** Before *any* deploy, publish, import, registration, push, or data write, the agent prints a gate naming the target environment, PAC profile (and any mismatch), target solution, exact components, delivery primitive, artifact provenance, blast radius, rollback plan, and timeout. If a required field is missing, it stops.
+- **Stale-artifact blocking.** It will not import a ZIP from `bin`, `Release`, `Downloads`, or a temp folder unless that package was generated in-session or you explicitly selected it. Multiple candidate packages → it stops and asks.
+- **Targeted delivery first.** It prefers the narrowest primitive — web-resource sync, plug-in push, form/ribbon patch, PCF wrapper deploy, keyed upsert — and **never silently escalates** a targeted change into a whole-solution import (a slow, high-blast-radius path that needs explicit approval).
+
+## How it's built
+
+PowerPlatform-Core is packaged as a plugin of modular skills over a shared toolchain:
+
+- **An orchestrator + 10 domain skills** under `skills/`, each with a focused, precisely triggering description.
+- **A shared toolchain at the plugin root**, resolved via `$CLAUDE_PLUGIN_ROOT` / `$CODEX_PLUGIN_ROOT`:
+  - **`scripts/`** — Python helper entry points that drive every live operation.
+  - **`tools/`** — a .NET 8 `DataverseOps` execution tool (connection checks, row/metadata ops, flows, plug-ins, web resources, solutions) plus a Windows auth dialog.
+  - **`references/`** — a knowledge base on surface selection, ALM, metadata, verification, and repo archetypes that the skills cite as needed.
+
+For the full picture, see [`docs/core-overlay-architecture.md`](docs/core-overlay-architecture.md) and the maintainer-oriented [`docs/capability-matrix.md`](docs/capability-matrix.md).
+
+## Standalone vs. overlay
+
+PowerPlatform-Core is the public, **repo-agnostic base** and is designed to be used directly — install it and point it at any Power Platform or Dataverse repo, no configuration required. That is the right choice for most users and unfamiliar repos.
+
+An **overlay** is a separate skill that layers one team's house-style conventions, references, and defaults on top of Core, bundling Core's runtime into a single merged skill. If your repo follows a specific team's conventions and an overlay exists, use that team's skill token; otherwise use Core. Building your own overlay is covered in [`docs/core-overlay-architecture.md`](docs/core-overlay-architecture.md).
+
+## Develop & verify
+
+Contributing or running a local checkout? One command verifies the whole repo:
+
+```bash
+python verify_repo.py
+```
+
+It runs Python syntax checks, the `unittest` suite, the skill-structure and manifest checks, the .NET build/tests for `DataverseOps`, and the skill-creator quick validator when available. Cross-platform: the Windows-only WPF auth dialog is skipped automatically on macOS/Linux.
+
+Maintainer detail — capability boundaries, current limitations, and the helper backlog — lives in [`docs/development.md`](docs/development.md).
+
+## License
+
+Apache-2.0 — see [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE).
+
+© 2026 Satrio Tsubasa.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,199 +1,41 @@
 ---
 name: powerplatform-core
-description: PowerPlatform-Core is a coding-agent skill for Microsoft Power Platform and Dataverse development. Use when Codex needs to read a repo, understand model-driven app and solution structure, and safely build, validate, or deliver source-controlled changes such as plug-ins, PCF controls, web resources, form metadata, RibbonDiffXml, solution-aware flows, Dataverse schema, configuration data, custom APIs, PAC CLI workflows, SDK/Web API automation, and solution ALM without assuming one house repo convention.
+description: >
+  Entry point for the PowerPlatform-Core plugin — a coding-agent skill for Microsoft Power
+  Platform and Dataverse development: model-driven apps, plug-ins, PCF controls, web resources,
+  form and ribbon metadata, solution-aware Power Automate flows, Dataverse schema, configuration
+  data, custom APIs, security roles, document generation, and solution ALM. Use whenever the user
+  works on Power Platform, Dataverse, Dynamics 365, Power Apps, Power Automate, or the pac CLI. The
+  full capability is split into focused skills under `skills/`; start with the `powerplatform-core`
+  orchestrator, which discovers repo context, routes to the right domain skill, and enforces the
+  mandatory live-mutation preflight.
 ---
 
-# Power Platform Development
+# PowerPlatform-Core
 
-PowerPlatform-Core is a coding-agent skill for Microsoft Power Platform and Dataverse development. Use it when you want Codex to read a repo, understand model-driven app and solution structure, and safely build, validate, and deliver source-controlled changes such as plug-ins, PCF controls, web resources, form metadata, RibbonDiffXml, solution-aware flows, Dataverse schema, and configuration data.
+PowerPlatform-Core is packaged as a plugin made of **modular skills**. The capability lives under **`skills/`**, and the shared toolchain (`scripts/`, `tools/`, `references/`) sits at the plugin root and is resolved via `$CLAUDE_PLUGIN_ROOT` / `$CODEX_PLUGIN_ROOT`.
 
-It is intentionally code-first for executable logic: prefer JavaScript, plug-ins, custom APIs, supported metadata APIs, SDK/Web API helpers, PAC CLI workflows, and repo-owned deploy wrappers over Business Rules, portal memory, browser automation, or stale solution packages.
+## Start here
 
-## How It Works
+Open the orchestrator: [`skills/powerplatform-core/SKILL.md`](skills/powerplatform-core/SKILL.md). It handles repo discovery, chooses the development surface, routes to the right domain skill, and enforces the shared safety rules.
 
-1. Discover repo context, project profile, source areas, local solution artifacts, and any active overlay skill before asking setup questions.
-2. Choose the right development surface: code, metadata, PCF, flow, config data, or solution ALM.
-3. Apply repo-backed changes first so the result is source-controlled and reviewable.
-4. Run a live mutation preflight before any deploy, publish, import, registration, push, or data write.
-5. Validate and deploy only through the approved targeted path unless the user explicitly accepts a broader blast radius.
+## Domain skills (under `skills/`)
 
-## Mandatory Live Mutation Preflight
+| Skill | For |
+| --- | --- |
+| `dataverse-schema` | tables, columns, lookups, forms, views, ribbon, icons, schema design |
+| `data-operations` | row create/update/upsert, query design |
+| `power-automate-flows` | solution-aware cloud flows: create/update/inspect/lint/review |
+| `plugins-server-extensions` | plug-ins, custom APIs, step registration and state |
+| `pcf-and-web-resources` | PCF controls, web resources, client scripts, Power Fx |
+| `code-apps` | Power Apps Code Apps (pro-code SPA model) |
+| `solution-alm-delivery` | solution pack/import/deploy, versioning, patch/merge, standards, delivery validation |
+| `security-roles` | security roles and privilege sets |
+| `document-generation` | Word Templates and document generation |
+| `custom-connectors` | custom connectors and integration wrappers |
 
-Before any live Dataverse mutation, print or capture a preflight gate. Use `scripts/validate_delivery.py --preflight-spec ...` when it fits; otherwise produce the same fields manually and stop if any required field is missing.
+## Non-negotiable safety rule
 
-Required fields:
+Before ANY live Dataverse mutation (deploy, publish, import, registration, push, or data write), run the **mandatory live-mutation preflight** defined in the orchestrator skill. Never import a stale ZIP from `bin`, `Release`, `Downloads`, or temp folders unless it was generated in-session or explicitly selected, and never silently escalate a targeted change into a whole-solution import.
 
-- target environment URL
-- active PAC profile and mismatch warning when PAC is involved
-- target solution unique name and whether it is a patch
-- mutation type: web resource, form, ribbon, plug-in, flow, PCF, config data, metadata, or solution import
-- exact components touched
-- delivery primitive
-- artifact path, creation/modification time, solution name/version, managed state, and component diff when any ZIP/package is used
-- blast radius: targeted, component subset, patch package, or full solution
-- rollback or recovery plan
-- timeout and fallback path
-- explicit confirmation when the primitive is not targeted
-
-If the delivery primitive becomes solution import, stop before import and state that this is no longer a fast targeted deploy, that it commonly takes 10-30 minutes including import, publish, cache refresh, and verification, and what narrower path was unavailable.
-
-Do not import a ZIP from `bin`, `Release`, `Downloads`, or old temp folders unless it was generated in the current session or explicitly selected by the user. If multiple package candidates exist, stop and ask. Do not silently escalate from a targeted helper to solution import.
-
-## Deployment And Pull Decision Matrix
-
-| Task | Preferred primitive | Stop condition |
-| --- | --- | --- |
-| One authored JS/HTML/CSS web resource changed | edit source, then `sync_webresource.py` | target solution or web resource name unclear |
-| Several web resources changed | `sync_webresources_batch.py` or repo wrapper | batch includes unrelated files |
-| Plug-in assembly/package changed | build, `push_plugin.py` or repo-owned plug-in wrapper, then step-state verification | registration target or critical step state unclear |
-| PCF changed | build/version with `version_pcf_solution.py`, deploy with `deploy_pcf.py` or wrapper solution | stale wrapper ZIP or unmanaged target unclear |
-| Form XML changed | `patch_form_xml.py`, `update_main_form.py`, or direct metadata update | helper cannot express the change |
-| Existing command, JS-only visibility/action logic changed | edit the web resource and deploy it with `sync_webresource.py` or `sync_webresources_batch.py` | command metadata also needs to change |
-| Form-level ribbon command changed | `patch_form_ribbon.py` or direct metadata update | new entity command, new button, new command, or new display rule is required |
-| Entity command bar, new button, new command, or new display rule changed | fresh selected solution/patch export, overlay only `Entities/<entity>/RibbonDiff.xml` and related web resources, bump version before import, pack/import, targeted publish, read back | selected solution/patch, entity, or package approval is unclear |
-| Other RibbonDiffXml changed | use the matching targeted metadata helper when it fits; otherwise use the fresh export/import recovery path | package import is the only remaining path |
-| Solution-aware flow changed | inspect/lint, then `update_flow.py` or `create_flow.py`; promote via solution ALM | semantic guard fails or connection refs unclear |
-| Config data rows changed | dry-run/diff through workflow or repo tool, then keyed `upsert_data.py`/SDK/Web API | no stable key or delete requested |
-| Need latest metadata reference | `ensure_dataverse_reference.py` to hydrate or refresh `Dataverse/<solution>` | live target solution ambiguous |
-| Existing unpacked source needs sync | `pac solution sync` on the known solution folder | repo and live both contain new work |
-| Unpack a specific artifact | inspect package metadata, then `pac solution unpack` to a reviewed folder | artifact freshness or solution identity unclear |
-| Solution import requested | fresh package only, `validate_delivery.py`, explicit blast-radius approval, then `deploy_solution.py` | targeted primitive exists or package may be stale |
-
-## Workflow
-
-1. Treat project context as runtime input, not fixed skill configuration. Do not assume one permanent environment URL, publisher prefix, solution name, or folder layout.
-2. Run `python scripts/discover_context.py --path .` first when the repo shape is not already obvious. Add `--include-pac-auth` only when live environment access matters and PAC CLI is available. The discovery output includes an `overlay_skills` section listing any installed skill whose `skill-package.json` declares `"extends": "powerplatform-core"`. If the repo matches an overlay's conventions, inform the user that a specialized extension is available and suggest using it.
-3. Read repo context first. If the repository already contains a solution file, solution project, unpacked solution files, plug-in code, PCF code, pipeline files, deployment settings, README architecture notes, or a project profile, infer the current project shape from those artifacts before asking questions.
-4. Check repo continuity docs early. If the repo lacks a useful root `README.md`, lacks `CODEX_HANDOFF.md`, or the user wants durable thread continuation, open [references/thread-continuity.md](references/thread-continuity.md) and create or update those files before deep implementation. Preserve any strong existing `README.md`; only merge a compact `Start Here` block near the top.
-5. If the repo matches a layered structure like `*.Business`, `*.Plugins`, `*.Data`, `WebResources`, `*.PCF`, `Word Templates`, `Dataverse`, or `Tools`, open [references/repo-archetypes.md](references/repo-archetypes.md) and follow that layout instead of forcing a new one. If the repo has strong documented local conventions, project profiles, or architecture notes, preserve those patterns instead of forcing a new house style.
-6. If the repo contains `.codex/power-platform.project-profile.json` or `power-platform.project-profile.json`, open [references/project-profile.md](references/project-profile.md) and treat that profile as the first clarification layer for main live solution, source areas, and repo conventions before falling back to broader inference.
-7. If environment URL, solution unique name, publisher prefix, managed strategy, or repo layout is still missing, gather only the missing values in [references/project-context-template.md](references/project-context-template.md) before any environment-bound or destructive work.
-8. Open [references/context-and-alm.md](references/context-and-alm.md) for auth, source-control layout, project discovery, `pac` workflows, environment safety, and Dataverse MCP guidance.
-9. Open [references/execution-automation.md](references/execution-automation.md) when the user wants Codex to execute the change end to end instead of only generating code or instructions.
-10. Open [references/helper-strategy.md](references/helper-strategy.md) when deciding whether to add a new reusable helper, when expanding the automation library, or when a capability is still workflow-driven and needs to be categorized.
-11. Open [references/execution-surface-guide.md](references/execution-surface-guide.md) when deciding between metadata, client script, plug-ins, custom APIs, flows, HTML web resources, or PCF.
-12. Open [references/verification-and-recovery.md](references/verification-and-recovery.md) when the task will mutate live Dataverse state, includes deployment, publish, import, registration, or repo-versus-live reconciliation work, or needs a precise completion standard before execution starts.
-13. Before live deployment, run the mandatory live mutation preflight: asset type, chosen primitive, exact components, artifact source, targeted support, manual-only status, timeout budget, fallback path, and blast radius. Prefer `scripts/validate_delivery.py --preflight-spec ...` for a single gate or `scripts/apply_requirement_spec.py` for coordinated requirements.
-14. Open only the task-specific references you need:
-   - [references/dataverse-design.md](references/dataverse-design.md) for requirement-to-schema design, alternate keys, and query-shape planning before metadata execution.
-   - [references/dataverse-metadata.md](references/dataverse-metadata.md) for tables, columns, relationships, forms, views, and icons.
-   - [references/data-operations.md](references/data-operations.md) for Dataverse row create, update, and upsert work.
-   - [references/security-roles.md](references/security-roles.md) for Dataverse security role inspection, creation, update, privilege-set design, and ALM cautions.
-   - [references/client-customization.md](references/client-customization.md) for form scripts, client APIs, and HTML/CSS/JS/TS web resources.
-   - [references/server-extensions.md](references/server-extensions.md) for plug-ins, custom APIs, and early-bound generation.
-   - [references/pcf-controls.md](references/pcf-controls.md) for PCF control design and delivery.
-   - [references/power-automate-flows.md](references/power-automate-flows.md) for solution-aware cloud flow creation, inspection, linting, hardening review, and ALM delivery.
-   - [references/solution-patches.md](references/solution-patches.md) for patch, merge, upgrade, and main-solution targeting decisions.
-   - [references/solution-standards.md](references/solution-standards.md) for repo standards review and convention enforcement.
-   - [references/power-fx.md](references/power-fx.md) for formula debugging, delegation review, and rewrite guidance.
-   - [references/custom-connectors.md](references/custom-connectors.md) for custom connector and integration-wrapper design.
-   - [references/document-generation.md](references/document-generation.md) for Word Templates, content controls, and document-generation change planning.
-   - [references/queries-and-xml.md](references/queries-and-xml.md) for Power Automate Dataverse queries, OData, FetchXML, LayoutXML, and solution XML.
-   - [references/code-apps.md](references/code-apps.md) for Power Apps Code Apps — architecture, Vite scaffold, Dataverse data source integration, CRUD patterns, ALM, and admin setup. If `discover_context.py` returns multiple entries in `code_apps` (multi-app `CodeApp/` folder pattern), list them and ask the user which app to target before running any build or push operation. Use `scripts/push_code_app.py --all` to push all apps in sequence.
-15. Keep every change solution-scoped. This means add or update only the scoped components in the target unmanaged solution or selected patch. It does not mean defaulting to solution package import.
-16. Prefer the automation ladder in [references/execution-automation.md](references/execution-automation.md): repo edits, SDK or Web API, solution XML, `pac` CLI, and direct deployment tools. Do not choose browser automation unless the user explicitly approves a fallback after headless options are exhausted.
-17. Prefer reusable helper scripts in `scripts/` when they already cover the task. Current helpers include `discover_context.py`, `auth_context.py`, `ensure_dataverse_reference.py`, `apply_requirement_spec.py`, `whoami.py`, `upsert_data.py`, `create_table.py`, `create_field.py`, `create_lookup.py`, `inspect_flow.py`, `lint_flow.py`, `review_flow_hardening.py`, `review_flow_connectors.py`, `create_flow.py`, `update_flow.py`, `get_flow_trigger_url.py`, `inspect_environment_variable.py`, `set_environment_variable_value.py`, `design_dataverse_schema.py`, `design_dataverse_query.py`, `review_solution_standards.py`, `debug_power_fx.py`, `design_custom_connector.py`, `plan_document_generation.py`, `plan_solution_patch_merge.py`, `update_main_form.py`, `patch_form_xml.py`, `patch_form_ribbon.py`, `update_form_events.py`, `bind_pcf_control.py`, `update_view.py`, `set_table_icon.py`, `sync_webresource.py`, `sync_webresources_batch.py`, `inspect_word_templates.py`, `create_custom_api.py`, `inspect_security_role.py`, `create_security_role.py`, `update_security_role.py`, `inspect_plugin_steps.py`, `ensure_plugin_step_state.py`, `register_plugin_headless.py`, `register_plugin_package_headless.py`, `scaffold_pcf_control.py`, `deploy_pcf.py`, `version_pcf_solution.py`, `add_solution_components.py`, `solution_version.py`, `deploy_solution.py`, `validate_delivery.py`, and `push_plugin.py`, and `push_code_app.py`.
-18. When a capability is not yet a helper, decide explicitly whether it belongs in:
-   - a deterministic dedicated helper
-   - a carefully designed helper with a stronger spec format
-   - the workflow layer with existing helpers underneath
-   Use [references/helper-strategy.md](references/helper-strategy.md) instead of leaving the boundary implicit.
-19. Prefer supported makers tools, CLI, SDK, and client APIs over unsupported DOM hacks or direct database assumptions. Edit raw XML only when the task explicitly requires it or when the source-controlled artifact is already XML.
-20. Validate the narrowest relevant surface:
-   - Solution work: inspect unpacked diffs, or run `pac solution sync`, `pack`, `unpack`, or `check` when appropriate.
-   - Plug-ins: restore and build, then confirm step registration assumptions.
-   - PCF: install dependencies, build, confirm manifest metadata, and when a wrapper `Solutions` project exists confirm the package artifact path and version alignment.
-   - Client scripts: verify handler signatures, logical names, and build output if TypeScript is used.
-   - Query or automation changes: verify logical names, null handling, and filter syntax.
-21. Keep `CODEX_HANDOFF.md` current when work spans major milestones, architecture decisions, environment execution, or repo structure changes.
-22. If the thread becomes long or context feels tight, notify the user before any recap or compaction and update `CODEX_HANDOFF.md` first. Do not pretend an exact context percentage is available; use a conservative heuristic.
-23. Report exactly what changed, what was inferred from the repo or discovery script, what was executed automatically, what was verified, what still requires environment access, and which publish, import, or registration steps were intentionally not performed.
-
-## Default Operating Assumptions
-
-- For live Dataverse SDK or Web API work, prefer the reusable auth dialog in `scripts/auth_context.py` so the user can confirm the target URL, complete a forced interactive sign-in, and select the exact working solution before execution starts.
-- Use `pac auth interactive` when the auth dialog is unavailable or the user explicitly wants PAC-only auth.
-- Warn when the requested live target does not match the active PAC profile environment URL. Do not silently continue without surfacing that mismatch.
-- Treat `DEV` as the working environment and `TEST` as deployment validation. Do not touch production.
-- Ask before delete, import, publish, register, push, or upgrade.
-- If Dataverse reports that another `Import` or `PublishAll` is already running, do not skip the step immediately. Prefer the helper retry window first, then report failure only after that wait-and-retry path is exhausted.
-- Do not hardcode one project's URL, publisher prefix, solution name, or folder layout into the skill. Discover or request them per task.
-- Treat the selected solution as authoritative for live work in that session. If the selected solution is a patch, do not assume merge or parent-solution targeting unless the user explicitly asks for it.
-- Prefer repo conventions first. If no structure exists, use the default layout in [references/context-and-alm.md](references/context-and-alm.md). Treat code-centric `.sln + Business/Data/Plugins/WebResources` repos as first-class Dataverse implementations, not partial failures.
-- Treat hybrid enterprise repos as normal. `Business`, `Plugins`, `Data`, `WebResources`, `Word Templates`, and `PCF` can all be source-of-truth areas while `Dataverse/` remains a metadata reference area and `Reference/` remains docs-only.
-- Do not introduce new Dataverse Business Rules as an implementation surface. For executable logic, prefer client script for form-scoped behavior and plug-ins or custom APIs for shared or server-side behavior.
-- Treat plug-in step enablement as explicit deployment state. After plug-in registration, push, or import work, verify that critical steps are still enabled and intentionally disabled steps remain disabled.
-- When the repo has a namespaced `*.Data` or similar project that is generated from early-bound tooling, treat it as generator-owned. Read it for context, build against it, and regenerate it when required, but do not hand-edit generated files there unless the user explicitly asks for a manual fix.
-- When a PCF package root contains a wrapper `Solutions` project, prefer that package flow for deployable artifacts. `Debug` artifacts normally come from `Solutions\bin\Debug`; `Release` artifacts normally come from `Solutions\bin\Release`.
-- Prefer repo-root continuity docs. Keep `README.md` as the entry point and `CODEX_HANDOFF.md` as the running state file when the work is expected to span multiple sessions or threads.
-- If the repo has a strong architecture README or technical guide, read the relevant sections before making structural changes.
-- Use best-practice naming: stable publisher prefix, explicit schema names, readable logical names, clear namespaces, and consistent casing.
-- Handle errors explicitly. Return actionable messages in plug-ins, custom APIs, scripts, and automation expressions.
-- Dataverse data create, update, and upsert are in scope when the user asks for them. Do not delete business data unless the user explicitly requests deletion and separately approves the action.
-- Treat solution-aware cloud flows as Dataverse workflow records for create or update work, but keep cross-environment promotion in the solution ALM path with connection references and environment variables.
-- Remember that PCF versioning usually has two surfaces: the `version` attribute in `ControlManifest.Input.xml` and the wrapper solution version in `Solutions\src\Other\Solution.xml`. Update both together with `scripts/version_pcf_solution.py` unless the repo clearly uses a different convention.
-- When the user asks for "latest", or the task depends on current CLI or runtime support, verify against official Microsoft documentation before assuming.
-- Prefer Dataverse MCP only for inspection or guided development when it is configured and the user allows it. Do not use it as a shortcut for destructive changes.
-- Treat browser automation as opt-in fallback only, not a default implementation path.
-- Do not rely on silent auto-compaction for continuity when a repo-level handoff file can be refreshed first.
-- If the repo has only supporting local solution source, such as a PCF packaging solution, do not present that supporting solution as the main app solution unless a project profile or the user confirms it.
-- The long-term goal is helper-first execution for deterministic operations and workflow-driven composition for repo-specific judgment. Do not leave that split implicit.
-
-## Reference Guide
-
-- [references/project-context-template.md](references/project-context-template.md)
-- [references/project-profile.md](references/project-profile.md)
-- [references/context-and-alm.md](references/context-and-alm.md)
-- [references/helper-strategy.md](references/helper-strategy.md)
-- [references/repo-archetypes.md](references/repo-archetypes.md)
-- [references/execution-automation.md](references/execution-automation.md)
-- [references/execution-surface-guide.md](references/execution-surface-guide.md)
-- [references/verification-and-recovery.md](references/verification-and-recovery.md)
-- [references/thread-continuity.md](references/thread-continuity.md)
-- [references/dataverse-design.md](references/dataverse-design.md)
-- [references/dataverse-metadata.md](references/dataverse-metadata.md)
-- [references/data-operations.md](references/data-operations.md)
-- [references/security-roles.md](references/security-roles.md)
-- [references/client-customization.md](references/client-customization.md)
-- [references/server-extensions.md](references/server-extensions.md)
-- [references/pcf-controls.md](references/pcf-controls.md)
-- [references/power-automate-flows.md](references/power-automate-flows.md)
-- [references/solution-patches.md](references/solution-patches.md)
-- [references/solution-standards.md](references/solution-standards.md)
-- [references/power-fx.md](references/power-fx.md)
-- [references/custom-connectors.md](references/custom-connectors.md)
-- [references/document-generation.md](references/document-generation.md)
-- [references/queries-and-xml.md](references/queries-and-xml.md)
-- [references/code-apps.md](references/code-apps.md)
-
-## Execution Notes
-
-- Follow existing solution layering and do not rename established schema artifacts without a migration reason.
-- Do not manually edit generated early-bound files in namespaced `*.Data` or similar generator-owned projects. Change generator settings or regenerate instead.
-- Use `scripts/discover_context.py` as the default repo triage tool before asking broad setup questions.
-- Use `scripts/auth_context.py` before live environment work when the user wants the forced-popup auth path or when the target environment needs explicit confirmation. The dialog should not release live context until the user has selected the working solution.
-- If the repo has a project profile, treat it as the first override layer for main live solution, source areas, and repo conventions before asking broad setup questions.
-- If the repo project profile contains `deploymentDefaults`, treat those values as the repo's operational deploy guidance for timeout budgets, manual-only surfaces, preferred deployment paths, plug-in verification defaults, and typed row-write coercion.
-- If the repo has a flow guard contract in `.codex/power-platform.flow-guards.json`, `power-platform.flow-guards.json`, or a project-profile `flowGuardSpecPath`, treat it as the semantic safety contract for critical flow updates.
-- If the repo has no local Dataverse solution source and the task needs live Dataverse work, prefer hydrating `Dataverse/<solution-unique-name>/` with `scripts/ensure_dataverse_reference.py` or the orchestration preflight instead of creating a `Reference/` folder.
-- Treat `Reference/` as external or human reference material, not as the default source of truth for deployment work. Treat `Word Templates/` as a first-class source area when the repo uses document-generation plug-ins or content-control-based templates.
-- Use `scripts/apply_requirement_spec.py` when the user gives a multi-step requirement or wants a coordinated end-to-end execution flow instead of a single isolated helper action.
-- Use `scripts/whoami.py` for a read-only Dataverse SDK connectivity check before higher-risk live operations when auth or environment targeting is uncertain.
-- Prefer `scripts/apply_requirement_spec.py` first for coordinated requirement execution, then fall back to `scripts/upsert_data.py`, `scripts/create_table.py`, `scripts/create_field.py`, `scripts/create_lookup.py`, `scripts/inspect_flow.py`, `scripts/lint_flow.py`, `scripts/review_flow_hardening.py`, `scripts/review_flow_connectors.py`, `scripts/create_flow.py`, `scripts/update_flow.py`, `scripts/get_flow_trigger_url.py`, `scripts/inspect_environment_variable.py`, `scripts/set_environment_variable_value.py`, `scripts/design_dataverse_schema.py`, `scripts/design_dataverse_query.py`, `scripts/review_solution_standards.py`, `scripts/debug_power_fx.py`, `scripts/design_custom_connector.py`, `scripts/plan_document_generation.py`, `scripts/plan_solution_patch_merge.py`, `scripts/update_main_form.py`, `scripts/patch_form_xml.py`, `scripts/patch_form_ribbon.py`, `scripts/update_form_events.py`, `scripts/bind_pcf_control.py`, `scripts/update_view.py`, `scripts/set_table_icon.py`, `scripts/sync_webresource.py`, `scripts/sync_webresources_batch.py`, `scripts/inspect_word_templates.py`, `scripts/create_custom_api.py`, `scripts/inspect_security_role.py`, `scripts/create_security_role.py`, `scripts/update_security_role.py`, `scripts/inspect_plugin_steps.py`, `scripts/ensure_plugin_step_state.py`, `scripts/register_plugin_headless.py`, `scripts/register_plugin_package_headless.py`, `scripts/scaffold_pcf_control.py`, `scripts/deploy_pcf.py`, `scripts/version_pcf_solution.py`, `scripts/add_solution_components.py`, `scripts/solution_version.py`, `scripts/deploy_solution.py`, `scripts/validate_delivery.py`, and `scripts/push_plugin.py` for narrower tasks.
-- For security-role work, prefer `scripts/inspect_security_role.py` for list or inspect, `scripts/create_security_role.py` for new custom roles, and `scripts/update_security_role.py` for privilege-set or metadata changes. Do not update system-generated roles unless the user explicitly approves it.
-- If the repo already has a safe deploy wrapper or deploy script for the current asset type, prefer that repo-owned entry point over reconstructing the same deployment sequence ad hoc. Otherwise fall back to the generic helpers and official tools in this skill.
-- During live execution, report the current command or primitive, expected duration class, timeout budget, blocker, and fallback instead of silently polling for long periods.
-- For model-driven command bars and subgrids, prefer static RibbonDiffXml commands with visibility or enablement delegated to JavaScript `CustomRule` in a web resource. Avoid XML `ValueRule` for selected-row field or status logic unless the same rule shape is already proven on the target live grid.
-- Use repo-root `README.md` plus `CODEX_HANDOFF.md` as the durable project memory layer when work is expected to continue across threads.
-- If the repo already has a strong `README.md`, do not overwrite it. Insert or update a compact "Start Here" block near the top, typically after the title and first summary paragraph.
-- Prefer headless implementation for forms, views, library registration, web resource deployment, PCF deployment, and metadata changes through solution files, Dataverse APIs, or CLI before considering any browser flow.
-- Do not silently escalate from a targeted helper to `deploy_solution.py` or another whole-solution import. If the required metadata or ribbon change exceeds the supported targeted helper surface, stop, explain the limitation, and ask whether the user wants to accept the broader deployment blast radius.
-- Treat whole-solution import in shared unmanaged environments as high risk because it can overwrite unrelated maker work. Require explicit approval before broadening a targeted-component or solution-subset change into a solution import.
-- For Dataverse row operations, prefer safe create, keyed update, or upsert through SDK or Web API. Do not choose delete paths unless the user explicitly asked for deletion and approved it.
-- For executable logic, do not choose Dataverse Business Rules. Use form script for form-session behavior, and use synchronous plug-ins or custom APIs for shared server-side behavior.
-- When creating new assets, choose the lightest supported option that fits the requirement without falling back to Dataverse Business Rules: metadata change, form script, web resource, PCF, plug-in, custom API, flow, then XML-only edit as a last resort.
-- For flow work, prefer inspecting or linting the live solution-aware cloud flow first, then update only the `workflow` properties that need to change. Use solution deployment for environment promotion instead of treating live create or update as the deployment mechanism.
-- For flow updates that change `clientData`, treat semantic regression as a deployment blocker by default. Do not accept emptied critical branches, removed switch cases, or missing required branch actions unless the user explicitly approves semantic drift.
-- For HTTP-trigger flow delivery, prefer a deterministic chain: create or update the solution-aware flow, resolve the signed callback URL with `scripts/get_flow_trigger_url.py`, set the environment variable value with `scripts/set_environment_variable_value.py`, then smoke test the endpoint if the user asked for validation.
-- Keep generated output reviewable. Small diffs beat large repacks when the repo already uses unpacked solutions.
-- If critical project inputs are still missing, ask concise questions instead of guessing on environment URLs, solution names, publisher prefixes, managed strategy, or target folder paths.
+See [`README.md`](README.md) for installation (Claude Code / Codex) and [`docs/`](docs) for architecture.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,82 @@
+# Development & Maintainer Notes
+
+This document holds the maintainer-oriented detail that used to live in the README: verification internals, capability boundaries, current limitations, and recommended follow-on work. The README itself stays focused on a new user evaluating, installing, and using the plugin.
+
+For the full capability breakdown, see [`capability-matrix.md`](capability-matrix.md). For Core-vs-overlay ownership and the install model, see [`core-overlay-architecture.md`](core-overlay-architecture.md).
+
+## Verification
+
+The canonical local verification entry point is `verify_repo.py` at the repo root:
+
+```bash
+python verify_repo.py
+```
+
+It runs, in order:
+
+- **Python syntax** — compiles `verify_repo.py` and every `*.py` under `scripts/` and `tests/`.
+- **Skill structure** — confirms each `skills/<name>/SKILL.md` has valid YAML frontmatter whose `name` matches its folder, and that the plugin manifests (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`) are valid JSON when present.
+- **Unit tests** — `python -m unittest discover -s tests -v`.
+- **.NET build** — builds `CodexPowerPlatform.DataverseOps` (multi-targets `net8.0`, plus `net8.0-windows` on Windows). The WPF `CodexPowerPlatform.AuthDialog` is built only on Windows.
+- **.NET tests** — runs `CodexPowerPlatform.DataverseOps.Tests` (targets `net8.0-windows`, so it runs on Windows only).
+- **Skill quick validation** — runs the skill-creator `quick_validate.py` when the validator is found under the Codex or Claude skill home; otherwise it is skipped with a note.
+
+Useful flags: `--skip-python`, `--skip-tests`, `--skip-dotnet`, `--skip-quick-validate`.
+
+The unit suite includes lightweight acceptance scenarios (`tests/acceptance_scenarios.json`, `tests/test_skill_acceptance_scenarios.py`) covering representative repo shapes: layered hybrid, unpacked-solution-first, ambiguous mixed, tool-only, and sparse repos with no established structure.
+
+## Design principles
+
+- Keep the skill generic. Do not hardcode one tenant, publisher prefix, namespace pattern, or repo layout.
+- Keep presentation and configuration work in metadata when possible.
+- For executable logic, prefer code-managed surfaces — client script for form-scoped behavior, plug-ins or custom APIs for shared server-side behavior. Do not introduce Dataverse Business Rules as an implementation surface.
+- Prefer repo-backed, headless-first execution over browser automation.
+- Surface PAC-profile vs. requested-target mismatches before live work rather than silently assuming the active PAC environment is correct.
+- Keep changes solution-scoped. Ask before delete, import, publish, register, push, or upgrade.
+- Treat project context as runtime input, not fixed skill configuration.
+- Optimize user waiting time, not just eventual completion. Fail fast when preflight says the surface is manual-only, unsupported, or timed out.
+
+## Current boundaries
+
+Core intentionally does **not**:
+
+- assume one house repo structure or namespace style;
+- ship overlay-owned house-style references;
+- imply that `scripts/upsert_data.py` supports a generic dry-run mode (it does not — that phase stays in the workflow or repo tooling layer);
+- default to browser automation when repo-backed or headless paths exist.
+
+Some capabilities remain partly workflow-driven rather than fully helper-packaged, especially:
+
+- bespoke XML surgery;
+- highly repo-specific architecture decisions;
+- environment-specific acceptance testing;
+- document-template authoring that depends on one team's conventions.
+
+## Known limitations today
+
+- **Cross-surface auth unification is incomplete.** Dataverse SDK helpers, the PAC CLI, and Power Apps admin flows still use separate auth stacks, so one extra Power Apps sign-in can occur for helper paths such as flow trigger-URL retrieval.
+- **First-time plug-in registration** is implemented for the two primary flows (assembly-based and package-based) and is primarily repo- and build-validated in this repo rather than broadly live-write regression-tested.
+- **User/team role assignment is not packaged yet.** Core can inspect, create, and update roles, but assigning roles to users or teams is still workflow-driven.
+- **Fully generic deployment/acceptance testing is not complete.** `scripts/validate_delivery.py` plus the repo-local regression suite cover safe validation well, but environment-specific acceptance helpers and broader live validation are still needed.
+- **No exact context-pressure meter** — the skill uses heuristics, not a real percentage.
+
+See [`capability-matrix.md`](capability-matrix.md) for the per-capability status, packaging category, and notes.
+
+## Maintenance rules
+
+- Make generic changes here first. Keep overlay-specific prompts, examples, and conventions out of Core.
+- If a repo already has a safe deploy wrapper, Core may use it — but Core should not prescribe one project-specific wrapper shape as a default.
+- Keep `README.md` focused on the new-user path (evaluate, install, use). Keep this file and `capability-matrix.md` for maintainer depth.
+- Keep `CODEX_HANDOFF.md` focused on current repo state and in-flight work, not static capability manuals.
+
+## Next recommended work
+
+From the helper backlog (see [`capability-matrix.md`](capability-matrix.md) for the full list):
+
+1. Live environment validation for the newest design and review helpers.
+2. Direct patch, merge, and solution-upgrade execution helpers.
+3. Richer Power Automate connector-specific authoring helpers.
+4. Document-template authoring helpers for stable repo patterns.
+5. Broader repo-profile adoption guidance across more repo archetypes.
+
+The one explicitly tracked optional follow-on is issue `#19` (an optional Azure control-plane reference as a secondary path), deferred behind the generic Core acceptance and verification foundation.

--- a/scripts/apply_requirement_spec.py
+++ b/scripts/apply_requirement_spec.py
@@ -1546,8 +1546,11 @@ def run_push_plugin_helper(
         command.append("--skip-step-state-reconcile")
     if value := options.get("stepStateSpec"):
         command.extend(["--step-state-spec", json.dumps(value) if isinstance(value, (dict, list)) else str(value)])
-    if value := options.get("maxRuntimeSeconds") or options.get("max_runtime_seconds"):
-        command.extend(["--max-runtime-seconds", str(value)])
+    max_runtime_value = options.get("maxRuntimeSeconds")
+    if max_runtime_value is None:
+        max_runtime_value = options.get("max_runtime_seconds")
+    if max_runtime_value is not None:
+        command.extend(["--max-runtime-seconds", str(max_runtime_value)])
 
     if connection:
         command.extend(build_child_live_args(connection, auth_flow=auth_flow, force_prompt=force_prompt, verbose=verbose))
@@ -1653,9 +1656,9 @@ def run_deploy_pcf_helper(options: dict[str, Any], *, repo: Path, connection: di
         command.append("--stage-and-upgrade")
     if options.get("convertToManaged"):
         command.append("--convert-to-managed")
-    if value := options.get("lockRetries"):
+    if (value := options.get("lockRetries")) is not None:
         command.extend(["--lock-retries", str(value)])
-    if value := options.get("lockWaitSeconds"):
+    if (value := options.get("lockWaitSeconds")) is not None:
         command.extend(["--lock-wait-seconds", str(value)])
     if value := options.get("verbosity"):
         command.extend(["--verbosity", str(value)])
@@ -1818,12 +1821,15 @@ def run_deploy_solution_helper(options: dict[str, Any], *, repo: Path, connectio
         command.append("--explicit-artifact-selection")
     if options.get("skipImport"):
         command.append("--skip-import")
-    if value := options.get("lockRetries"):
+    if (value := options.get("lockRetries")) is not None:
         command.extend(["--lock-retries", str(value)])
-    if value := options.get("lockWaitSeconds"):
+    if (value := options.get("lockWaitSeconds")) is not None:
         command.extend(["--lock-wait-seconds", str(value)])
-    if value := options.get("maxRuntimeSeconds") or options.get("max_runtime_seconds"):
-        command.extend(["--max-runtime-seconds", str(value)])
+    max_runtime_value = options.get("maxRuntimeSeconds")
+    if max_runtime_value is None:
+        max_runtime_value = options.get("max_runtime_seconds")
+    if max_runtime_value is not None:
+        command.extend(["--max-runtime-seconds", str(max_runtime_value)])
 
     environment_url = options.get("environmentUrl")
     if not environment_url and connection:
@@ -1961,8 +1967,12 @@ def script_name_to_step_type(script_name: str) -> str:
         "add_solution_components.py": "add-solution-components",
         "register_plugin_headless.py": "register-plugin-assembly",
         "register_plugin_package_headless.py": "register-plugin-package",
+        "update_main_form.py": "update-main-form",
+        "update_view.py": "update-view",
+        "update_form_events.py": "update-form-events",
+        "sync_webresources_batch.py": "sync-webresources-batch",
     }
-    return mapping[script_name]
+    return mapping.get(script_name, "")
 
 
 def deep_copy_json(value: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/auth_context.sh
+++ b/scripts/auth_context.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+# POSIX wrapper for auth_context.py (macOS/Linux counterpart of auth_context.cmd
+# and auth_context.ps1). Forwards all arguments to the Python entry point.
+#
+# Note: the interactive WPF auth dialog is Windows-only. On macOS/Linux this
+# wrapper still runs auth_context.py, which resolves the connection from explicit
+# arguments / the active PAC profile and uses the device-code sign-in flow.
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$DIR/auth_context.py" "$@"

--- a/scripts/debug_power_fx.py
+++ b/scripts/debug_power_fx.py
@@ -12,6 +12,8 @@ from typing import Any
 from powerplatform_common import read_json_argument, repo_root, write_json_output
 
 FUNCTION_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+STRING_LITERAL_RE = re.compile(r"\"(?:[^\"]|\"\")*\"|'(?:[^']|'')*'")
+IN_OPERATOR_RE = re.compile(r"\b(in|exactin)\b", re.IGNORECASE)
 DELEGATION_FUNCTIONS = {"Search", "Distinct", "AddColumns", "GroupBy", "Ungroup", "ForAll"}
 WRITE_FUNCTIONS = {"Patch", "SubmitForm", "Collect", "ClearCollect", "Remove", "RemoveIf", "UpdateIf"}
 
@@ -130,8 +132,8 @@ def find_delegation_risks(formula: str, functions: list[str]) -> list[dict[str, 
                     "message": f"{function_name} often needs delegation review against the connected data source.",
                 }
             )
-    lowered = formula.lower()
-    if " exactin " in lowered or " in " in lowered:
+    stripped = STRING_LITERAL_RE.sub(" ", formula)
+    if IN_OPERATOR_RE.search(stripped):
         findings.append(
             {
                 "severity": "medium",

--- a/scripts/deploy_pcf.py
+++ b/scripts/deploy_pcf.py
@@ -53,6 +53,7 @@ def main() -> int:
     parser.add_argument("--convert-to-managed", action="store_true", help="Convert to managed during solution import in solution-package mode.")
     parser.add_argument("--lock-retries", type=int, default=20, help="Number of retry waits for Dataverse import or publish locks before failing.")
     parser.add_argument("--lock-wait-seconds", type=int, default=30, help="Seconds to wait between Dataverse import or publish lock retries.")
+    parser.add_argument("--max-runtime-seconds", type=float, default=600.0, help="Maximum seconds allowed for the npm install, npm build, and pac push or import steps before failing.")
     parser.add_argument("--verbosity", choices=["minimal", "normal", "detailed", "diagnostic"], help="PAC PCF push verbosity.")
     parser.add_argument("--output", help="Optional JSON output path.")
     args = parser.parse_args()
@@ -62,13 +63,13 @@ def main() -> int:
     package_root = Path(pcf_context["package_root"])
 
     if not args.skip_install:
-        run_command(["npm", "install"], cwd=package_root)
+        run_command(["npm", "install"], cwd=package_root, timeout_seconds=args.max_runtime_seconds)
 
     if not args.skip_build:
         build_command = ["npm", "run", "build"]
         if args.production:
             build_command.extend(["--", "--buildMode", "production"])
-        run_command(build_command, cwd=package_root)
+        run_command(build_command, cwd=package_root, timeout_seconds=args.max_runtime_seconds)
 
     mode = resolve_mode(args.mode, pcf_context)
     version_alignment = evaluate_version_alignment(pcf_context)
@@ -202,6 +203,7 @@ def execute_direct_push(
         cwd=package_root,
         retries=args.lock_retries,
         wait_seconds=args.lock_wait_seconds,
+        max_runtime_seconds=args.max_runtime_seconds,
     )
 
     return {
@@ -344,7 +346,10 @@ def build_solution_wrapper(solution_project: Path, *, configuration: str, cwd: P
     try:
         run_command(msbuild_command, cwd=cwd)
         return
-    except Exception as msbuild_error:
+    except FileNotFoundError as msbuild_error:
+        # msbuild is not installed: fall back to dotnet build. A genuine compile
+        # failure (non-zero exit -> RuntimeError) is NOT caught here so a real
+        # build error surfaces instead of triggering a second full build.
         dotnet_command = [
             "dotnet",
             "build",

--- a/scripts/design_dataverse_query.py
+++ b/scripts/design_dataverse_query.py
@@ -7,8 +7,9 @@ import argparse
 import sys
 from pathlib import Path
 from typing import Any
+from xml.sax.saxutils import escape, quoteattr
 
-from powerplatform_common import read_json_argument, repo_root, write_json_output
+from powerplatform_common import read_json_argument, write_json_output
 
 
 def main() -> int:
@@ -25,7 +26,6 @@ def main() -> int:
         print("ERROR: --spec must resolve to a JSON object.", file=sys.stderr)
         return 2
 
-    repo_root(Path(args.repo_root))
     payload = build_query_design(spec)
     write_json_output(payload, args.output)
     return 0
@@ -76,7 +76,7 @@ def build_query_design(spec: dict[str, Any]) -> dict[str, Any]:
             "topCount": int(top) if top is not None else None,
             "fetchXml": fetch_xml,
         },
-        "warnings": build_query_warnings(filters, top, select, entity_set_name, filters),
+        "warnings": build_query_warnings(filters, top, select, entity_set_name),
     }
 
 
@@ -84,9 +84,9 @@ def build_fetchxml(table_logical_name: str, select: list[str], filters: list[dic
     parts = ["<fetch"]
     if top is not None:
         parts.append(f" count=\"{int(top)}\"")
-    parts.append(f"><entity name=\"{table_logical_name}\">")
+    parts.append(f"><entity name={quoteattr(str(table_logical_name))}>")
     for column in select:
-        parts.append(f"<attribute name=\"{column}\" />")
+        parts.append(f"<attribute name={quoteattr(str(column))} />")
     if filters:
         parts.append("<filter type=\"and\">")
         for item in filters:
@@ -94,21 +94,21 @@ def build_fetchxml(table_logical_name: str, select: list[str], filters: list[dic
             operator = normalize_operator(str(item.get("operator") or "eq"))
             value = item.get("value")
             if operator in {"null", "not-null"} or value is None:
-                parts.append(f"<condition attribute=\"{field}\" operator=\"{operator}\" />")
+                parts.append(f"<condition attribute={quoteattr(field)} operator={quoteattr(operator)} />")
             elif operator == "in":
-                parts.append(f"<condition attribute=\"{field}\" operator=\"in\">")
+                parts.append(f"<condition attribute={quoteattr(field)} operator=\"in\">")
                 for child_value in ensure_list(value):
-                    parts.append(f"<value>{child_value}</value>")
+                    parts.append(f"<value>{escape(str(child_value))}</value>")
                 parts.append("</condition>")
             elif operator in {"contains", "startswith", "endswith"}:
-                parts.append(f"<condition attribute=\"{field}\" operator=\"like\" value=\"{render_fetch_like_value(operator, value)}\" />")
+                parts.append(f"<condition attribute={quoteattr(field)} operator=\"like\" value={quoteattr(render_fetch_like_value(operator, value))} />")
             else:
-                parts.append(f"<condition attribute=\"{field}\" operator=\"{operator}\" value=\"{value}\" />")
+                parts.append(f"<condition attribute={quoteattr(field)} operator={quoteattr(operator)} value={quoteattr(str(value))} />")
         parts.append("</filter>")
     for item in order_by:
         field = require_text(item, "field")
         descending = str(item.get("direction") or "asc").strip().lower() == "desc"
-        parts.append(f"<order attribute=\"{field}\" descending=\"{str(descending).lower()}\" />")
+        parts.append(f"<order attribute={quoteattr(field)} descending=\"{str(descending).lower()}\" />")
     parts.append("</entity></fetch>")
     return "".join(parts)
 
@@ -147,7 +147,6 @@ def build_query_warnings(
     top: Any,
     select: list[str],
     entity_set_name: str | None,
-    filter_items: list[dict[str, Any]],
 ) -> list[str]:
     warnings = []
     if not entity_set_name:
@@ -158,7 +157,7 @@ def build_query_warnings(
         warnings.append("The query has no explicit top limit, so list actions may return large result sets.")
     if not select:
         warnings.append("The query has no explicit select list, so connector defaults may return wider payloads than necessary.")
-    if any(normalize_operator(str(item.get("operator") or "eq")) == "in" for item in filter_items):
+    if any(normalize_operator(str(item.get("operator") or "eq")) == "in" for item in filters):
         warnings.append("The query uses an 'in' filter. Validate OData support for the specific Dataverse action, or prefer FetchXML if the connector rejects it.")
     return warnings
 

--- a/scripts/design_dataverse_schema.py
+++ b/scripts/design_dataverse_schema.py
@@ -8,6 +8,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Any
+from xml.sax.saxutils import quoteattr
 
 from powerplatform_common import discover_repo_context, infer_publisher_prefix, read_json_argument, repo_root, write_json_output
 
@@ -317,9 +318,9 @@ def build_query_example(pattern: dict[str, Any], *, table_logical_name: str, pri
     if not isinstance(filters, list):
         filters = []
 
-    fetch_parts = [f"<fetch><entity name=\"{table_logical_name}\">"]
+    fetch_parts = [f"<fetch><entity name={quoteattr(str(table_logical_name))}>"]
     for column in select:
-        fetch_parts.append(f"<attribute name=\"{column}\" />")
+        fetch_parts.append(f"<attribute name={quoteattr(str(column))} />")
     if filters:
         fetch_parts.append("<filter type=\"and\">")
         for condition in filters:
@@ -331,9 +332,9 @@ def build_query_example(pattern: dict[str, Any], *, table_logical_name: str, pri
             operator = text_value(condition, "operator") or "eq"
             value = condition.get("value")
             if value is None:
-                fetch_parts.append(f"<condition attribute=\"{field}\" operator=\"{operator}\" />")
+                fetch_parts.append(f"<condition attribute={quoteattr(field)} operator={quoteattr(operator)} />")
             else:
-                fetch_parts.append(f"<condition attribute=\"{field}\" operator=\"{operator}\" value=\"{value}\" />")
+                fetch_parts.append(f"<condition attribute={quoteattr(field)} operator={quoteattr(operator)} value={quoteattr(str(value))} />")
         fetch_parts.append("</filter>")
     for sort in order_by:
         if not isinstance(sort, dict):
@@ -342,7 +343,7 @@ def build_query_example(pattern: dict[str, Any], *, table_logical_name: str, pri
         if not field:
             continue
         descending = str(sort.get("direction", "asc")).strip().lower() == "desc"
-        fetch_parts.append(f"<order attribute=\"{field}\" descending=\"{str(descending).lower()}\" />")
+        fetch_parts.append(f"<order attribute={quoteattr(field)} descending=\"{str(descending).lower()}\" />")
     fetch_parts.append("</entity></fetch>")
 
     odata_parts = []

--- a/scripts/discover_context.py
+++ b/scripts/discover_context.py
@@ -671,6 +671,7 @@ def inspect_pac_auth() -> list[dict[str, object]]:
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
         )
     except FileNotFoundError:
         return []

--- a/scripts/inspect_word_templates.py
+++ b/scripts/inspect_word_templates.py
@@ -16,6 +16,15 @@ WORD_NAMESPACE = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/
 WORD_TEMPLATE_SUFFIXES = {".docx", ".dotx"}
 WORD_PART_PREFIX = "word/"
 WORD_PART_SUFFIXES = {".xml"}
+# Parts under word/ that never carry content controls; match exact part names
+# (or the theme/ subfolder) so legitimate parts like word/customStyles.xml are
+# not excluded by a loose substring such as "/styles".
+WORD_PART_EXCLUDED_NAMES = {
+    "word/styles.xml",
+    "word/styleswitheffects.xml",
+    "word/fonttable.xml",
+}
+WORD_PART_EXCLUDED_PREFIXES = ("word/theme/",)
 
 
 def main() -> int:
@@ -101,7 +110,7 @@ def inspect_template(path: Path, *, repo: Path, summary_only: bool) -> dict[str,
             lower = part_name.lower()
             if not lower.startswith(WORD_PART_PREFIX) or Path(lower).suffix not in WORD_PART_SUFFIXES:
                 continue
-            if "/theme/" in lower or "/fonttable" in lower or "/styles" in lower:
+            if lower in WORD_PART_EXCLUDED_NAMES or lower.startswith(WORD_PART_EXCLUDED_PREFIXES):
                 continue
             with archive.open(part_name) as stream:
                 try:
@@ -120,7 +129,7 @@ def inspect_template(path: Path, *, repo: Path, summary_only: bool) -> dict[str,
 
     document = {
         "path": str(path),
-        "relativePath": str(path.relative_to(repo)) if path.is_relative_to(repo) else str(path),
+        "relativePath": path.relative_to(repo).as_posix() if path.is_relative_to(repo) else str(path),
         "fileName": path.name,
         "controlCount": len(controls),
         "duplicateTags": sorted(name for name, count in duplicate_tags.items() if count > 1),

--- a/scripts/powerplatform_common.py
+++ b/scripts/powerplatform_common.py
@@ -266,9 +266,9 @@ def resolve_authoritative_unpacked_solution(
 
 def active_pac_profile() -> dict[str, str | None]:
     try:
-        auth_who = run_command(["pac", "auth", "who"], check=False)
-        auth_list = run_command(["pac", "auth", "list"], check=False)
-    except OSError:
+        auth_who = run_command(["pac", "auth", "who"], check=False, timeout_seconds=30)
+        auth_list = run_command(["pac", "auth", "list"], check=False, timeout_seconds=30)
+    except (OSError, RuntimeError):
         return {
             "user": None,
             "tenant_id": None,
@@ -873,6 +873,14 @@ def launch_auth_dialog(
     tenant_id: str | None = None,
     auto_validate: bool = False,
 ) -> dict[str, Any]:
+    if os.name != "nt":
+        raise RuntimeError(
+            "The interactive authentication dialog is Windows-only (it is a WPF app). "
+            "On macOS/Linux, use the headless path instead: pass --environment-url and "
+            "--solution-unique-name explicitly and let sign-in use the device-code flow "
+            "(the DataverseOps tool prints a device code to complete in a browser)."
+        )
+
     build_dotnet_project(dataverse_tool_project())
     build_dotnet_project(auth_dialog_project())
 
@@ -880,27 +888,26 @@ def launch_auth_dialog(
     temporary.close()
     output_path = Path(temporary.name)
 
-    args = [
-        str(auth_dialog_exe()),
-        "--output-path",
-        str(output_path),
-        "--tool-dll-path",
-        str(dataverse_tool_dll()),
-    ]
-    if target_url:
-        args.extend(["--initial-target-url", target_url])
-    if username:
-        args.extend(["--initial-username", username])
-    if tenant_id:
-        args.extend(["--initial-tenant-id", tenant_id])
-    if auto_validate:
-        args.append("--auto-validate")
-
-    completed = run_command(args, cwd=skill_root(), check=False)
-    if not output_path.exists():
-        raise RuntimeError("Authentication dialog did not produce an output payload.")
-
     try:
+        args = [
+            str(auth_dialog_exe()),
+            "--output-path",
+            str(output_path),
+            "--tool-dll-path",
+            str(dataverse_tool_dll()),
+        ]
+        if target_url:
+            args.extend(["--initial-target-url", target_url])
+        if username:
+            args.extend(["--initial-username", username])
+        if tenant_id:
+            args.extend(["--initial-tenant-id", tenant_id])
+        if auto_validate:
+            args.append("--auto-validate")
+
+        completed = run_command(args, cwd=skill_root(), check=False)
+        if not output_path.exists():
+            raise RuntimeError("Authentication dialog did not produce an output payload.")
         payload = json.loads(output_path.read_text(encoding="utf-8"))
     finally:
         output_path.unlink(missing_ok=True)

--- a/scripts/powerplatform_common.py
+++ b/scripts/powerplatform_common.py
@@ -64,6 +64,7 @@ def run_command(
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             timeout=timeout_seconds,
         )
     except subprocess.TimeoutExpired as exc:
@@ -373,6 +374,16 @@ def dataverse_tool_project() -> Path:
     return skill_root() / "tools" / "CodexPowerPlatform.DataverseOps" / "CodexPowerPlatform.DataverseOps.csproj"
 
 
+def dataverse_tool_framework() -> str:
+    """Pick the .NET target framework the DataverseOps tool runs under.
+
+    The tool multi-targets net8.0 (cross-platform: browser/device-code auth) and
+    net8.0-windows (adds the Windows WAM broker). On Windows we run the windows build
+    so broker sign-in is unchanged; on macOS/Linux we run the plain net8.0 build.
+    """
+    return "net8.0-windows" if os.name == "nt" else "net8.0"
+
+
 def dataverse_tool_dll() -> Path:
     return (
         skill_root()
@@ -380,7 +391,7 @@ def dataverse_tool_dll() -> Path:
         / "CodexPowerPlatform.DataverseOps"
         / "bin"
         / "Debug"
-        / "net8.0-windows"
+        / dataverse_tool_framework()
         / "CodexPowerPlatform.DataverseOps.dll"
     )
 
@@ -406,7 +417,7 @@ def build_dotnet_project(project_path: Path) -> None:
 
 
 def run_dataverse_tool(command_args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
-    args = ["dotnet", "run", "--project", str(dataverse_tool_project()), "--"] + command_args
+    args = ["dotnet", "run", "--project", str(dataverse_tool_project()), "-f", dataverse_tool_framework(), "--"] + command_args
     return run_command(args, cwd=cwd or skill_root())
 
 
@@ -937,6 +948,16 @@ def resolve_live_connection(
         username_value = payload.get("username") or payload.get("Username") or resolved_username
         tenant_value = payload.get("tenantId") or payload.get("TenantId") or resolved_tenant_id
         selected_solution = payload.get("selectedSolution") or payload.get("SelectedSolution") or {}
+        if not environment_value:
+            raise RuntimeError(
+                "The authentication dialog did not return an environment URL. Complete the "
+                "interactive sign-in and solution selection, or pass --environment-url explicitly."
+            )
+        if not username_value:
+            raise RuntimeError(
+                "The authentication dialog did not return a username. Complete the interactive "
+                "sign-in before continuing."
+            )
         return {
             "environment_url": environment_value,
             "username": username_value,

--- a/scripts/push_code_app.py
+++ b/scripts/push_code_app.py
@@ -27,12 +27,24 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
+import subprocess
 import sys
 from pathlib import Path
-import subprocess
 
 
 CONFIG_FILE = "power.config.json"
+
+
+def resolve_executable(name: str) -> str:
+    """Resolve a command name to a concrete path.
+
+    On Windows, tools like npm/npx/pac ship as .cmd shims that ``subprocess``
+    (without ``shell=True``) will not find by bare name. ``shutil.which`` honours
+    PATHEXT and returns the real target; we fall back to the bare name so the
+    caller's FileNotFoundError handling still fires when the tool is missing.
+    """
+    return shutil.which(name) or name
 
 
 def find_config(app_path: Path) -> Path | None:
@@ -73,7 +85,7 @@ def discover_app_paths(root: Path) -> list[Path]:
 
 def check_node_available() -> bool:
     try:
-        subprocess.run(["node", "--version"], capture_output=True, check=True)
+        subprocess.run([resolve_executable("node"), "--version"], capture_output=True, check=True)
         return True
     except (FileNotFoundError, subprocess.CalledProcessError):
         return False
@@ -81,7 +93,7 @@ def check_node_available() -> bool:
 
 def check_pac_available() -> bool:
     try:
-        subprocess.run(["pac", "help"], capture_output=True, check=True)
+        subprocess.run([resolve_executable("pac"), "help"], capture_output=True, check=True)
         return True
     except (FileNotFoundError, subprocess.CalledProcessError):
         return False
@@ -92,7 +104,8 @@ def run_command(cmd: list[str], cwd: Path, dry_run: bool) -> int:
     if dry_run:
         print("  [dry-run: skipped]")
         return 0
-    result = subprocess.run(cmd, cwd=cwd)
+    resolved = [resolve_executable(cmd[0]), *cmd[1:]]
+    result = subprocess.run(resolved, cwd=cwd)
     return result.returncode
 
 
@@ -145,7 +158,23 @@ def push_single_app(app_path: Path, cli: str, solution_name: str | None,
     return rc
 
 
+def _make_console_utf8_safe() -> None:
+    """Best-effort: switch stdout/stderr to UTF-8 so the box-drawing and check
+    characters in this script's output do not raise UnicodeEncodeError on a
+    cp1252 Windows console. Silently no-ops on streams that cannot reconfigure.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass
+
+
 def main() -> int:
+    _make_console_utf8_safe()
     parser = argparse.ArgumentParser(
         description="Build and push Power Apps code app(s) to Power Platform.",
     )

--- a/scripts/register_plugin_package_headless.py
+++ b/scripts/register_plugin_package_headless.py
@@ -79,9 +79,12 @@ def main() -> int:
     spec = apply_selected_solution_to_spec(spec, connection)
     spec = apply_plugin_step_state_defaults_to_registration_spec(spec, load_plugin_step_state_contract(repo))
     spec["packagePath"] = str(package_file)
-    spec.setdefault("uniqueName", package_metadata.get("id"))
-    spec.setdefault("name", package_metadata.get("title") or package_metadata.get("id"))
-    spec.setdefault("version", package_metadata.get("version"))
+    if package_metadata.get("id"):
+        spec.setdefault("uniqueName", package_metadata["id"])
+    if package_metadata.get("title") or package_metadata.get("id"):
+        spec.setdefault("name", package_metadata.get("title") or package_metadata.get("id"))
+    if package_metadata.get("version"):
+        spec.setdefault("version", package_metadata["version"])
     if package_metadata.get("description") and not spec.get("description"):
         spec["description"] = package_metadata["description"]
 

--- a/scripts/scaffold_pcf_control.py
+++ b/scripts/scaffold_pcf_control.py
@@ -18,6 +18,7 @@ def main() -> int:
     parser.add_argument("--template", default="field", choices=["field", "dataset"], help="PCF template type.")
     parser.add_argument("--framework", choices=["none", "react"], default="none", help="PCF framework option.")
     parser.add_argument("--run-npm-install", action="store_true", help="Run npm install during pac pcf init.")
+    parser.add_argument("--max-runtime-seconds", type=float, default=600.0, help="Maximum seconds allowed for pac pcf init (including npm install when requested) before failing.")
     parser.add_argument("--output", help="Optional JSON output path.")
     args = parser.parse_args()
 
@@ -43,7 +44,7 @@ def main() -> int:
     if args.run_npm_install:
         command.append("--run-npm-install")
 
-    run_command(command, cwd=repo)
+    run_command(command, cwd=repo, timeout_seconds=args.max_runtime_seconds)
 
     manifest_path = output_dir / "ControlManifest.Input.xml"
     write_json_output(

--- a/scripts/solution_version.py
+++ b/scripts/solution_version.py
@@ -58,7 +58,6 @@ def main() -> int:
         revision_version=args.revision_version,
     )
     updated_text = VERSION_RE.sub(rf"\g<1>{new_version}\g<3>", xml_text, count=1)
-    solution_xml.write_text(updated_text, encoding="utf-8")
 
     online_updated = False
     connection = None
@@ -72,7 +71,15 @@ def main() -> int:
             auto_validate=args.auto_validate,
         )
 
-    solution_name = args.solution_name or (connection["solution_unique_name"] if connection else None) or infer_solution_name(updated_text)
+    selected_solution_name = connection["solution_unique_name"] if connection else None
+    if args.solution_name and selected_solution_name and args.solution_name != selected_solution_name:
+        raise RuntimeError(
+            "Conflicting online versioning target: --solution-name "
+            f"'{args.solution_name}' does not match the auth-dialog-selected solution "
+            f"'{selected_solution_name}'. Pass a matching --solution-name or omit it."
+        )
+
+    solution_name = args.solution_name or selected_solution_name or infer_solution_name(updated_text)
     if args.online:
         if not solution_name:
             raise RuntimeError("Could not infer the solution unique name for online versioning. Pass --solution-name.")
@@ -88,8 +95,17 @@ def main() -> int:
             "--environment",
             environment_url,
         ]
-        run_command(command, cwd=repo)
+        # Write the local file just before the online sync so we can roll it back
+        # if the online step fails and avoid leaving the repo bumped on failure.
+        solution_xml.write_text(updated_text, encoding="utf-8")
+        try:
+            run_command(command, cwd=repo)
+        except Exception:
+            solution_xml.write_text(xml_text, encoding="utf-8")
+            raise
         online_updated = True
+    else:
+        solution_xml.write_text(updated_text, encoding="utf-8")
 
     write_json_output(
         {

--- a/scripts/sync_webresources_batch.py
+++ b/scripts/sync_webresources_batch.py
@@ -130,6 +130,7 @@ def main() -> int:
                 break
 
     publish_result = None
+    publish_warning = None
     if publish_after_all and changed_and_requested_publish:
         command = [
             "webresource",
@@ -151,7 +152,14 @@ def main() -> int:
         if args.verbose:
             command.append("--verbose")
         completed = run_dataverse_tool(command, cwd=repo)
-        publish_result = json.loads(completed.stdout)
+        try:
+            publish_result = json.loads(completed.stdout)
+        except (json.JSONDecodeError, ValueError) as exc:
+            publish_warning = (
+                f"The publish-many step completed but returned a non-JSON response: {exc}. "
+                "The web resources were synced; verify the publish manually if needed."
+            )
+            publish_result = {"raw": completed.stdout, "warning": publish_warning}
 
     payload = {
         "success": success,
@@ -161,6 +169,8 @@ def main() -> int:
         "publishResult": publish_result,
         "results": results,
     }
+    if publish_warning:
+        payload["publishWarning"] = publish_warning
     if error_message:
         payload["error"] = error_message
 

--- a/scripts/update_flow.py
+++ b/scripts/update_flow.py
@@ -64,7 +64,6 @@ def main() -> int:
         auto_validate=args.auto_validate,
     )
     spec = apply_selected_solution_to_spec(spec, connection)
-    flow_identity = build_flow_identity(spec, None)
     proposed_client_data = spec.get("clientData")
     semantic_guard = None
     baseline_client_data = None
@@ -131,7 +130,13 @@ def main() -> int:
                 comparison_label="post-deploy",
             )
             if post_findings:
-                raise RuntimeError(build_semantic_guard_error(post_findings))
+                if not args.allow_semantic_drift:
+                    raise RuntimeError(build_semantic_guard_error(post_findings))
+                print(
+                    "WARNING: post-deploy semantic drift detected but allowed via --allow-semantic-drift:\n"
+                    + build_semantic_guard_error(post_findings),
+                    file=sys.stderr,
+                )
         print(completed.stdout.strip())
         return 0
     finally:

--- a/scripts/version_pcf_solution.py
+++ b/scripts/version_pcf_solution.py
@@ -57,6 +57,12 @@ def main() -> int:
         increment=args.increment,
     )
 
+    if not args.version and not args.increment and new_solution_version == normalize_solution_version(str(current_version)):
+        parser.error(
+            "No version change requested. Pass --version or --increment "
+            "(the computed version matches the current version, so nothing would change)."
+        )
+
     updated_manifest_paths = []
     update_all = args.update_all_manifests or len(source_manifest_paths) > 1
     for manifest_path in source_manifest_paths:

--- a/skill-package.json
+++ b/skill-package.json
@@ -8,7 +8,11 @@
     "scripts",
     "references",
     "assets",
-    "tools"
+    "tools",
+    "skills",
+    ".claude-plugin",
+    ".codex-plugin",
+    ".agents"
   ],
   "excludeDirectories": [
     ".git",

--- a/skills/code-apps/SKILL.md
+++ b/skills/code-apps/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: code-apps
+description: >
+  Use for Power Apps Code Apps — the pro-code app-hosting model where a Vite-built React/Vue/TS
+  single-page app uses the `@microsoft/power-apps` client library and is pushed into a Power
+  Platform environment with no server to manage. Covers scaffolding from the official Vite
+  template, initializing with `power.config.json`, adding Dataverse data sources that generate
+  typed model/service files, local dev, building, and pushing via `npx power-apps push` (npm CLI)
+  or legacy `pac code push`. Trigger this whenever the user mentions a code app, `power.config.json`,
+  `@microsoft/power-apps`, `pac code` / `power-apps` CLI, a `CodeApp/` folder, or wants to build,
+  run, or push a custom SPA into Power Platform — even if no helper is named. This is NOT for PCF
+  controls embedded in forms or for Canvas/maker apps.
+---
+
+# Power Apps Code Apps
+
+Power Apps Code Apps is the code-first SPA hosting model: a standard web app (React/Vue/TS, built with Vite) that imports the `@microsoft/power-apps` client library and is published into a Power Platform environment, where the platform handles Entra authentication, DLP, sharing, and Conditional Access. It is distinct from PCF (components inside model-driven forms) and Canvas apps (built in maker studio). Keep the app source-controlled, build before every push, and treat `power.config.json` as the bridge between the local project and the target environment.
+
+## When to use this
+
+- Scaffold a new code app from the Microsoft Vite template and initialize it against an environment.
+- Add Dataverse (or connector) data sources and use the generated typed services for CRUD.
+- Run the app locally, build it, and push it to a Power Platform environment.
+- Work in a repo that uses the multi-app `CodeApp/` folder pattern (several code apps side by side).
+- Plan ALM promotion (Dev → Test → Prod) via solutions, pipelines, and connection references.
+
+For a control embedded inside a model-driven form, use `pcf-and-web-resources`. For Dataverse schema or data operations behind the app, use `dataverse-schema` and `data-operations`.
+
+## Helpers
+
+Helpers live in the plugin's `scripts/` directory at the plugin root, not inside this skill folder. Resolve the plugin root and invoke them:
+
+- Claude Code: `python "$CLAUDE_PLUGIN_ROOT/scripts/push_code_app.py" --help`
+- Codex: `python "$CODEX_PLUGIN_ROOT/scripts/push_code_app.py" --help` (also exposed as `$PLUGIN_ROOT`)
+- Standalone / unsure: the `scripts/` folder sits beside this skill bundle; invoke by its path within the install.
+
+| Helper | Use it to |
+| --- | --- |
+| `push_code_app.py` | Build (`npm run build`) and push a code app. Defaults to the npm CLI (`npx power-apps push`); pass `--cli pac` for legacy `pac code push` and `--solution-name <unique>` to target a specific solution. Use `--path <dir>` to point at one app, `--all` to push every app under a `CodeApp/` folder in sequence, `--dry-run` to preview, and `--skip-build` only when pushing already-compiled output. |
+
+Discovery: the orchestrator's `discover_context.py` reports detected code-app roots (and their display names / environment IDs) in its `code_apps` key. A repo is a code app when `power.config.json` exists at the root or in a subdirectory.
+
+## Workflow
+
+1. **Scaffold.** `npx degit github:microsoft/PowerAppsCodeApps/templates/vite my-app`, then `npm install`. Do not introduce a second app toolchain if the template already provides one.
+2. **Initialize.** `npx power-apps init` (or `--displayName`/`--environmentId` non-interactively) writes `power.config.json` and authenticates against the environment.
+3. **Add data sources.** `pac code add-data-source -a dataverse -t <table>` generates typed `…Model.ts` and `…Service.ts` files under `/generated/services/`. Do not hand-edit generated files — regenerate instead. Use `select` to limit columns; exclude system-managed fields from create payloads; send only changed fields on update.
+4. **Develop locally.** `npm run dev`, opening the Local Play URL in the same browser profile as the tenant. Note that Chrome/Edge block public-origin requests to localhost by default (since Dec 2025) — grant the prompt or configure `allow="local-network-access"`.
+5. **Build, then push.** `npm run build` (`tsc -b && vite build`), then push with `push_code_app.py`. The push returns a Power Apps URL to run and share the app.
+6. **Promote via ALM.** Add the app to a solution (maker portal → Add existing → App → Code app) and promote through Power Platform Pipelines. Use connection references instead of hardcoded connector credentials so the solution moves across environments cleanly.
+
+## Safety and decision rules
+
+- Before any push or other live mutation, run the **mandatory live-mutation preflight from the `powerplatform-core` orchestrator** and stop if any required field is missing. A push publishes into a live environment — treat it as a mutation, not a build step.
+- **Build, then push.** Never push without a fresh `npm run build` unless the user explicitly asks to push existing compiled output (`--skip-build`), and say so when you do.
+- **List multiple apps before pushing.** If discovery returns more than one entry in `code_apps` (the multi-app `CodeApp/` pattern), list them and confirm the target before running any build or push. Use `--all` only when the user wants every app pushed in sequence; otherwise scope with `--path`.
+- Prefer the npm CLI (`npx power-apps push`) going forward; `pac code push` is legacy and being deprecated. Use `--cli pac` only when the repo or task requires it.
+- Confirm the active environment matches `power.config.json` (`environmentId`) and the intended target before pushing; warn on any mismatch. Treat the dev environment as the working target and do not push to production without explicit approval.
+- Respect the known limitations: no `pac solution pack/unpack` for code apps, no FetchXML / alternate keys / polymorphic lookups / Dataverse actions via generated services, no Power Platform Git integration, and no Power Apps mobile/Windows support. End users need a Power Apps Premium license, and an admin must enable the Code Apps feature on the environment.
+- Code Apps is in preview; verify current CLI and runtime support against official Microsoft docs when the task depends on "latest" behavior.
+- Report what was built, which app(s) were pushed, the returned app URL(s), and any ALM/admin steps still pending.
+
+## References
+
+- `references/code-apps.md` — architecture, Vite scaffold, npm vs pac CLI, Dataverse data-source integration and CRUD patterns, ALM, admin/security, known limitations, and the multi-app detection model.

--- a/skills/custom-connectors/SKILL.md
+++ b/skills/custom-connectors/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: custom-connectors
+description: >
+  Use for designing Power Platform custom connectors and integration wrappers — reviewing an
+  OpenAPI/Swagger description, choosing the auth shape (API key, OAuth2, basic, none), taking an
+  operation inventory, and deciding whether to expose an API as a direct custom connector or
+  behind an Azure Function / API facade. Produces a connector name, auth approach, operation
+  summaries, a recommended pattern, suggested environment variables, and solution-aware
+  connection-reference guidance. Trigger this whenever the user mentions a custom connector,
+  OpenAPI/Swagger for Power Platform, connecting a flow or app to an external/REST API, an
+  integration wrapper or facade, or asks whether an Azure Function should sit in front of an
+  integration — even if no helper is named. This is design-first, not a connector publisher.
+---
+
+# Custom Connectors and Integration Wrappers
+
+This skill helps design how Power Platform talks to an external API: reviewing the API description, settling the authentication shape, inventorying operations, and — critically — recommending whether the integration should be a direct custom connector or sit behind an Azure Function / API facade. It is design-first. It produces a reviewed structure and recommendation; the actual connector publish or Azure delivery still needs its own implementation path. Keep the result solution-aware with explicit connection references and environment variables so it promotes cleanly across environments.
+
+## When to use this
+
+- Review an OpenAPI/Swagger document or a structured integration requirement for connector suitability.
+- Recommend an auth approach and inventory the operations to expose.
+- Decide direct custom connector vs Azure Function / API facade.
+- Plan the environment variables and connection references the integration needs for ALM.
+
+For the flow that will *call* the connector, use `power-automate-flows`. For server-side logic inside Dataverse, use `plugins-server-extensions`.
+
+## Helpers
+
+Helpers live in the plugin's `scripts/` directory at the plugin root, not inside this skill folder. Resolve the plugin root and invoke them:
+
+- Claude Code: `python "$CLAUDE_PLUGIN_ROOT/scripts/design_custom_connector.py" --help`
+- Codex: `python "$CODEX_PLUGIN_ROOT/scripts/design_custom_connector.py" --help` (also exposed as `$PLUGIN_ROOT`)
+- Standalone / unsure: the `scripts/` folder sits beside this skill bundle; invoke by its path within the install.
+
+| Helper | Use it to |
+| --- | --- |
+| `design_custom_connector.py` | Review an OpenAPI description or structured requirement and emit a connector name, auth approach, operation summaries, a recommended pattern (direct connector vs facade), suggested environment variables, and connection-reference guidance. |
+
+## Workflow
+
+1. **Inspect the source.** Read the OpenAPI/Swagger description or the structured integration requirement before deciding anything.
+2. **Judge direct-connector fit.** A clean, REST-shaped, JSON API with standard auth is a good direct custom-connector candidate.
+3. **Prefer a facade when the shape is hard.** If the integration involves binary payloads, heavy transformation, fan-out/orchestration, or non-REST behavior, recommend an Azure Function (or similar) facade first and expose *that* as the connector.
+4. **Settle auth.** Recommend the auth approach (API key, OAuth2, basic, none) that matches the API and the platform's supported connector auth types.
+5. **Keep it solution-aware.** Plan explicit connection references and environment variables so credentials are not hardcoded and the connector promotes across Dev → Test → Prod.
+6. **Hand off delivery.** State clearly what still needs a separate implementation path: publishing the connector, or building and deploying the Azure facade.
+
+## Safety and decision rules
+
+- This helper recommends structure and pattern; it does not publish a connector or deploy an Azure resource. Do not describe a connector as "created" or "deployed" beyond the design output.
+- Default to a facade for binary, transform-heavy, fan-out, or non-REST integrations rather than forcing an awkward direct connector.
+- Never hardcode secrets, endpoints, or tenant-specific values into the connector definition — route them through environment variables and connection references.
+- If any connector or Azure delivery step performs a live mutation in an environment, run the **mandatory live-mutation preflight from the `powerplatform-core` orchestrator** first and stop if any required field is missing.
+- When the task depends on current supported connector auth types or CLI behavior, verify against official Microsoft documentation before assuming.
+
+## References
+
+- `references/custom-connectors.md` — OpenAPI-based connector design review, auth recommendations, the direct-vs-facade decision path, expected output, and the design-first limits of the helper.

--- a/skills/data-operations/SKILL.md
+++ b/skills/data-operations/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: data-operations
+description: >
+  Use whenever the user wants to read or write Dataverse business or configuration data — create,
+  update, or upsert rows, seed or sync reference/config data, or design a query — rather than
+  change table metadata. Trigger on phrases like "create a record/row", "update this record",
+  "upsert by alternate key", "seed config data", "import/sync these rows", "set a field value on
+  a row", or "design an OData / FetchXML query" and "build the List rows filter for a flow", even
+  when the user never names a helper script. Prefer this skill for keyed create/update/upsert via
+  SDK or Web API and for query design across OData, FetchXML, and Power Automate "List rows".
+---
+
+# Data Operations
+
+This skill owns Dataverse row create/update/upsert and query design. It is the data branch of the `powerplatform-core` orchestrator — start there to discover repo context and confirm the target environment and solution. Keep data work separate from schema work: a solution import is not the way to sync environment-specific config data, and creating/changing tables or columns belongs in the `dataverse-schema` skill.
+
+Default safety posture: create, update, and upsert are in scope when the user asks for them. Do not delete business data unless the user explicitly requests deletion and separately approves it.
+
+## When to use this
+
+- Create a single row, or create-or-update by primary key or alternate key.
+- Update only the columns that changed on a known record.
+- Seed or sync reference/configuration data into an environment.
+- Design a query and get the OData path, FetchXML, and Power Automate "List rows" parameters for a structured spec.
+
+For table/column/lookup/form/view/ribbon/icon changes, use the `dataverse-schema` skill instead.
+
+## Helpers
+
+The Python helpers live in the plugin's **`scripts/`** directory at the plugin root, not inside this skill folder. Resolve the plugin root and invoke a helper like this (use `$CODEX_PLUGIN_ROOT`, also exposed as `$PLUGIN_ROOT`, when running under Codex; if installed standalone, the `scripts/` folder sits beside this bundle):
+
+- **Claude Code:** `python "$CLAUDE_PLUGIN_ROOT/scripts/upsert_data.py" --table contoso_account --data ./row.json --key ./key.json --auth-dialog --verify`
+- **Codex:** `python "$CODEX_PLUGIN_ROOT/scripts/upsert_data.py" --table contoso_account --data ./row.json --key ./key.json --auth-dialog --verify`
+
+- `design_dataverse_query.py` — offline query designer. Takes `--spec` (a JSON object or path describing `tableLogicalName`, `entitySetName`, `select`, `filters`, `orderBy`, `top`, `expand`) plus optional `--repo-root` / `--output`. Emits a Web API OData path, FetchXML, Power Automate "List rows" parameters, and warnings about missing filters, row limits, select lists, or entity-set names. No live call.
+- `upsert_data.py` — live row write. Key flags: `--table` (logical name, required), `--data` (JSON object or path, required), `--mode {create,update,upsert}` (default `upsert`), `--id` (primary-key GUID for update/upsert), `--key` (JSON object or path with alternate-key values), `--verify` (retrieve the changed columns after the write), plus the shared auth flags (`--environment-url`/`--target-url`, `--username`, `--tenant-id`, `--auth-dialog`, `--auto-validate`, `--auth-flow {auto,devicecode,interactive}`, `--force-prompt`, `--verbose`) and `--repo-root` (resolves project-profile deployment defaults, including typed row-write coercion).
+
+If the repo already has a proven seed-data or data-sync mechanism, or server-side SDK code, prefer that repo-owned path over reconstructing one. The Web API is the simpler direct/scriptable path when no SDK code exists.
+
+## Workflow
+
+1. **Confirm targeting before writing.** Resolve the target environment, the table logical name (and entity set name when querying), whether the operation is create-only, update-only, or create-or-update, the matching key (record ID, alternate key, or agreed lookup), the exact columns to set, and duplicate-handling expectations. If ambiguous, ask only for the missing high-risk parts.
+2. **Choose the mode deliberately.** Use `create` to let Dataverse assign the key; `update` to send only changed columns by primary or alternate key; `upsert` for create-or-update when the row might already exist. For Web API update-only behavior, `If-Match: *` prevents a silent upsert.
+3. **Key choice for rerunnable work.** For integration/migration/rerunnable writes, prefer alternate keys over user-editable business fields, and prefer immutable keys. When the source identifier comes from another system, do not rely on a bare reused ID unless it is globally unique in the tenant — prefer a source-system-qualified key (`source_system + source_id`).
+4. **Resolve lookups and choices safely.** Bind lookups using supported references, not display-name guessing; use logical names and valid choice values; reuse early-bound classes, enums, or constants when the repo already has them; prefer reference tables or global choices over repeated free text for controlled value sets.
+5. **Plan before bulk/config apply.** For config-data sync, imports, migrations, or bulk corrections, run a dry-run/diff/plan phase first that names rows to be created, updated, skipped, invalid, and any target-only rows present in Dataverse but missing from the source extract (that last category drives whether deactivation, deletion, or an explicit no-op policy is needed). Do not apply config data to TST/TEST until that plan exists.
+6. **Apply and verify.** Validate the smallest possible payload, use `--verify` when confirming the write matters, and capture whether the action created or updated the row.
+7. **Preserve provenance.** When syncing from another source, keep enough provenance to identify origin, retain source-system-qualified keys when multiple upstreams may reuse an external ID, and avoid casually overwriting provenance columns used for reconciliation or audit.
+
+## Key safety and decision rules
+
+- **Run the live-mutation preflight defined in the `powerplatform-core` orchestrator before any live row write.** Stop if any required field is missing.
+- Prefer the auth dialog (`--auth-dialog`) so the user confirms the target URL and selects the working solution; warn when the requested target does not match the active PAC profile. Treat `DEV` as the working environment and `TEST` as validation. Do not touch production.
+- **Capability boundary:** `upsert_data.py` performs live row writes and optional post-write verification — it does **not** have a generic dry-run/plan mode. When a dry-run is required, keep that phase in the workflow or repo-specific tooling layer; do not imply the shared helper already supports it.
+- Do not delete business data unless the user explicitly asked for deletion and separately approved it. Prefer safe create, keyed update, or upsert over any delete path.
+- Separate solution customization from configuration rows. A solution import is not the default way to sync environment-specific config data.
+- If no write executed because a required key or environment value was missing, say so explicitly. When a write is performed, report the table targeted, whether it created/updated/upserted, the key or alternate key used, which columns changed, and what safety checks were applied.
+
+## Query design notes
+
+- Prefer the simplest query that matches the requirement: use logical names (not display names), select only needed columns, set row limits and pagination intentionally, and guard against nulls and empty arrays.
+- Use OData (`$select`, then `$filter` only for necessary predicates, `$expand` sparingly) for straightforward server-side filtering. Dataverse Web API does not support every OData option; if the query needs complex joins, aggregates, or view definitions, prefer FetchXML.
+- If the entity set name is unknown, provide it explicitly in the helper input rather than guessing a pluralized logical name.
+- For Power Automate expressions, prefer clear guards (`coalesce`, `if`, `empty`) over nested fragile expressions. Validate `in` filters against the specific connector action, falling back to FetchXML if rejected.
+
+## References
+
+Read the shared references at the plugin's `references/` directory for depth:
+
+- `references/data-operations.md` — create/update/upsert paths, keying and provenance, dry-run/apply planning, and validation/reporting.
+- `references/queries-and-xml.md` — OData and FetchXML guidance, view `FetchXml`/`LayoutXml`, and direct solution XML rules.

--- a/skills/dataverse-schema/SKILL.md
+++ b/skills/dataverse-schema/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: dataverse-schema
+description: >
+  Use whenever the user wants to create or change Dataverse table metadata — tables, columns,
+  lookups and relationships, choices/option sets, alternate keys, main forms, public/lookup
+  views, the form-level ribbon (RibbonDiffXml), form event handlers and script libraries, or
+  table icons — and for up-front schema and query-shape design before any metadata is created.
+  Trigger on phrases like "create a table", "add a column/field", "add a lookup", "add a choice",
+  "set an alternate key", "update the main form", "add a view / change view columns", "add a
+  button to the form ribbon", "set the table icon", or "design a Dataverse schema", even when the
+  user never names a helper script or file. Prefer this skill over hand-edited customizations.xml
+  for routine table, column, form, view, ribbon, and icon work.
+---
+
+# Dataverse Schema
+
+This skill owns Dataverse schema work: turning a requirement into tables, columns, lookups, alternate keys, forms, views, the form-level ribbon, and table icons, and applying those changes through the shared SDK metadata helpers. It is the metadata branch of the `powerplatform-core` orchestrator — start there to discover repo context (`scripts/discover_context.py`), confirm the target solution and publisher prefix, and pick the lightest surface. Keep every change solution-scoped: add or update only the scoped components in the target unmanaged solution or selected patch; that does not mean defaulting to a whole-solution import.
+
+Prefer supported, source-controlled metadata APIs and the helpers below over hand-edited `customizations.xml`. Edit raw form/ribbon/view XML only when the task explicitly requires it or when the unpacked solution already stores that artifact as XML.
+
+## When to use this
+
+- Create or modify tables, columns, lookups/relationships, choices, or alternate keys.
+- Update a main form's layout, add fields/sections/subgrids, or register form libraries and event handlers.
+- Change a public, lookup, or personal view's columns, sorting, or filter (FetchXml and/or LayoutXml).
+- Patch a form-level command bar (RibbonDiffXml) on one named form.
+- Set or change a custom table's icon from image web resources.
+- Design a schema or query shape for review before creating anything live.
+
+For row create/update/upsert and standalone query authoring (OData/FetchXML/"List rows"), use the `data-operations` skill instead. For entity-level command bars, new buttons/commands, or new display rules, that exceeds the form-ribbon helper — see the workflow note below.
+
+## Helpers
+
+The Python helpers live in the plugin's **`scripts/`** directory at the plugin root, not inside this skill folder. Resolve the plugin root and invoke a helper like this (use `$CODEX_PLUGIN_ROOT`, also exposed as `$PLUGIN_ROOT`, when running under Codex; if installed standalone, the `scripts/` folder sits beside this bundle):
+
+- **Claude Code:** `python "$CLAUDE_PLUGIN_ROOT/scripts/create_table.py" --spec ./table.json --auth-dialog`
+- **Codex:** `python "$CODEX_PLUGIN_ROOT/scripts/create_table.py" --spec ./table.json --auth-dialog`
+
+Design helpers (offline planning — take `--spec` plus optional `--repo-root` / `--output`, no live write):
+
+- `design_dataverse_schema.py` — turn a structured requirement into resolved logical/schema names, alternate-key candidates, relationship definitions, starter FetchXML/OData, and helper-ready specs for `create_table.py`, `create_field.py`, and `create_lookup.py`.
+
+Live metadata helpers (each takes `--spec` — a JSON object or a path to a JSON file — plus shared auth flags: `--environment-url`/`--target-url`, `--username`, `--tenant-id`, `--auth-dialog`, `--auto-validate`, `--auth-flow {auto,devicecode,interactive}`, `--force-prompt`, `--verbose`):
+
+- `create_table.py` — create a table (primary name, ownership, notes/activities/audit).
+- `create_field.py` — create a column (string, memo, integer, decimal, money, boolean, datetime, choice, multiselect, etc.).
+- `create_lookup.py` — create a lookup relationship between two tables.
+- `update_main_form.py` — update a named main form's layout (tabs, sections, field placement, subgrids).
+- `update_form_events.py` — register form script libraries and event handler bindings on a form.
+- `patch_form_xml.py` — targeted `systemform.formxml` patch operations (replace header/body fragments, insert XML, set element attributes) on a named form; also accepts `--repo-root`.
+- `patch_form_ribbon.py` — targeted form-level `RibbonDiffXml` patch operations on a named form; also accepts `--repo-root`.
+- `update_view.py` — update a named view's `FetchXml` and/or `LayoutXml` (columns, widths, sort, filter).
+- `set_table_icon.py` — set a custom table's icon metadata from existing image web resources.
+
+## Workflow
+
+1. **Discover and confirm context first.** Run the orchestrator's discovery, then confirm publisher prefix, target solution unique name, environment URL, and ownership model before creating anything. Prefer stable schema names; do not rename existing schema names casually — forms, views, flows, and code depend on them.
+2. **Design before live creation.** For non-trivial schema, run `design_dataverse_schema.py` to produce reviewable names, alternate keys, relationships, and query examples. Treat it as a design layer, not a deployment shortcut. If the task is "create a field" with no detail, ask for the data type and whether it belongs on forms, views, or automation filters.
+3. **Order of operations.** Create the table, then its columns, then lookups/relationships. Add or move fields on the form, then reflect them in the relevant views, quick find, and any client script or server-side validation. For an end-to-end lookup addition, update the relationship, the form placement, and impacted view columns together.
+4. **Alternate keys.** If a column will be an integration/import key, design it to be immutable over the record lifetime; if the candidate value can change, define a key-rotation or mapping approach before treating it as the rerun key.
+5. **Forms.** Keep form diffs minimal. Use `update_main_form.py` for layout, `update_form_events.py` for library/handler registration, and `patch_form_xml.py` for targeted XML fragment patches. Target the smallest XPath and fragment that satisfies the requirement.
+6. **Views.** When the change is XML-based, adjust `FetchXml` (records and sort) and `LayoutXml` (visible columns) together when the request changes both data and presentation. Ensure any referenced image web resources or JavaScript functions are part of the same solution change.
+7. **Ribbon (form-level only).** Use `patch_form_ribbon.py` for targeted form-level command changes. For subgrid command visibility/enablement, prefer static command definitions plus JavaScript `CustomRule` in a web resource; avoid XML `ValueRule` for selected-row field or status logic unless that exact rule shape is already proven on the target live grid.
+8. **Icons.** Use `set_table_icon.py` with existing image web resources. Do not invent image files — if the user does not provide assets, ask for them; confirm whether both classic and unified interface entries need updates.
+9. **Finish cohesively.** Treat "create a table/field/lookup" as incomplete until you also check whether the component is in the target solution, whether the app/sitemap needs it exposed, whether forms and views should include the new field, and whether automation or scripts depend on the new logical name. Do not treat app-module exposure as implied just because a component exists in solution metadata.
+
+## Key safety and decision rules
+
+- **Run the live-mutation preflight defined in the `powerplatform-core` orchestrator before any live metadata write** (create, update, patch, icon, or import). Stop if any required field is missing.
+- Prefer the auth dialog (`--auth-dialog`) so the user confirms the target URL and selects the working solution before execution; warn when the requested target does not match the active PAC profile. Treat `DEV` as the working environment and `TEST` as validation. Do not touch production.
+- Do not introduce Dataverse Business Rules. Use client script for form-scoped behavior and plug-ins or custom APIs for shared server-side behavior.
+- Do not silently escalate from a targeted helper to a whole-solution import. If a ribbon or metadata change exceeds the targeted helper surface — entity-level command bars, new buttons, new commands, or new display rules — stop and explain that this needs the fresh export/overlay/import recovery path (fresh selected solution or patch export, overlay only `Entities/<entity>/RibbonDiff.xml` and related web resources, bump version, import, targeted publish, read-back) and ask before accepting the broader blast radius.
+- Ask before delete, import, or publish. Do not rename established schema artifacts without a migration reason.
+- Edit unpacked XML only when required; preserve encoding and formatting, keep diffs minimal, update related files together, and call out any publish step still required for the change to take effect. Verify logical names and XML well-formedness before finishing.
+- Report what changed, what was inferred, what was executed, what was verified, and which publish/import steps were intentionally not performed.
+
+## References
+
+Read the shared references at the plugin's `references/` directory for depth:
+
+- `references/dataverse-design.md` — requirement-to-schema design, alternate keys, and query-shape planning before metadata execution.
+- `references/dataverse-metadata.md` — tables, columns, relationships, forms, views, icons, and app/sitemap exposure.
+- `references/queries-and-xml.md` — FetchXml/LayoutXml, view XML, form/ribbon XML, and direct solution XML editing rules.

--- a/skills/document-generation/SKILL.md
+++ b/skills/document-generation/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: document-generation
+description: >
+  Use for ANY Dataverse document-generation task built on Word Templates — inventory the
+  content controls in a `.docx`/`.dotx` template, map placeholders to data, and plan a
+  template-aware change before editing the template blindly. Fires whenever the user mentions
+  a Word Template, document generation, content controls, placeholder or merge-field mapping,
+  document-definition records, "why is this field blank in the generated doc", "add a placeholder
+  to the template", "what tags does this template use", or a document-generation plug-in — even
+  if no helper is named. It treats `Word Templates/` as first-class source, surfaces duplicate
+  tags, missing required placeholders, and unused controls, and points at the `*.Business`,
+  `*.Plugins`, and `*.Data` touchpoints a placeholder change implies. Run the live-mutation
+  preflight from the `powerplatform-core` orchestrator before any live template or component write.
+---
+
+# Document Generation — Word Templates and Placeholder Mapping
+
+This skill handles Power Platform document generation that uses Word Templates and content controls. It inventories the content controls inside `.docx`/`.dotx` templates, maps requested placeholders against what the template actually exposes, and plans template-aware changes — flagging duplicate tags, missing required placeholders, and unused controls before anyone edits a template blindly. It treats `Word Templates/` as a first-class source area and connects a placeholder change to the `*.Business`, `*.Plugins`, and document-definition data it depends on. It is intentionally generic about environment, publisher prefix, solution name, and folder layout — discover those per task.
+
+## When to use this
+
+- The user wants to know which content controls, tags, or aliases a template contains.
+- A placeholder or merge field needs to be added, renamed, or remapped, and you need to know what it touches.
+- A generated document has a blank or wrong field and you need to map the placeholder back to its data source.
+- The user wants required-versus-optional placeholders validated against a template before a change.
+- You are scoping a document-generation change across `Word Templates`, `Business`, `Plugins`, and `Data` source areas.
+
+Route here from the `powerplatform-core` orchestrator. For solution packaging or promotion of templates and related components, use the `solution-alm-delivery` sibling skill.
+
+## Helpers
+
+The helpers live in the plugin's `scripts/` directory at the plugin root, not in this skill folder. Resolve the plugin root and invoke them like:
+
+- `python "$CLAUDE_PLUGIN_ROOT/scripts/inspect_word_templates.py" --path <template-or-dir>` (Claude Code)
+- `python "$CODEX_PLUGIN_ROOT/scripts/inspect_word_templates.py" --path <template-or-dir>` (also exposed as `$PLUGIN_ROOT`)
+- Installed standalone / unsure: the `scripts/` folder sits beside this skill bundle — invoke by its path within the install.
+
+| Helper | Purpose |
+| --- | --- |
+| `inspect_word_templates.py` | Inspect `.docx`/`.dotx` files and summarize their content controls. Defaults to the inferred `Word Templates` area; pass `--path` for a specific file or directory, `--recurse` for a directory tree, and `--summary-only` for per-file summaries without full control detail. Read-only inventory. |
+| `plan_document_generation.py` | Plan a template-aware document-generation change from a `--spec` (template path or name, placeholder mappings, required-versus-optional placeholders, and entity/document-definition context). Returns current content controls, duplicate tags and aliases, mapped placeholders, missing required placeholders, unused controls, and the `Word Templates`/`Business`/`Plugins`/`Data` source-area touchpoints. Planning only. |
+
+## Domain workflow
+
+1. **Inventory the template first.** Run `inspect_word_templates.py` against the real template so you work from the actual content controls, tags, and aliases rather than assumptions.
+2. **Plan before editing.** Run `plan_document_generation.py` with the requested placeholder mappings to see mapped placeholders, missing required placeholders, duplicate tags, and unused controls — plus the source-area touchpoints the change implies.
+3. **Trace meaning changes to their source.** When a placeholder changes meaning, inspect the related `*.Business`, `*.Plugins`, and document-definition data before editing the template, rather than changing the tag in isolation.
+4. **Keep templates source-controlled.** Treat `Word Templates/` as the deployable source; do not treat `Reference/` copies of templates as deployable source by default.
+5. **Hand off structural redesign with judgment.** Inspection and planning are helper-backed; creating or redesigning `.docx` structure still needs repo-specific judgment and should stay review-driven until a stronger repeated pattern emerges.
+
+## Safety and decision rules
+
+- **`Word Templates/` is first-class source; `Reference/` is not.** Plan and edit against the deployable template, not a reference copy.
+- **Do not retag blindly.** A placeholder is a contract with the generation logic — confirm the `*.Business`/`*.Plugins`/document-definition side before renaming or remapping a tag.
+- **Surface duplicates and gaps explicitly.** Report duplicate tags/aliases, missing required placeholders, and unused controls instead of silently editing around them.
+- **Keep structural redesign review-driven.** Lean on the helpers for inspection and mapping; treat new `.docx` structure as repo-specific work that needs explicit review.
+- **Preflight gate.** Run the mandatory live-mutation preflight from the `powerplatform-core` orchestrator before any live template or related component write. Do not restate the full preflight here — invoke it there.
+
+## References
+
+- `references/document-generation.md` — primary helpers, operating rules, template planning inputs, what the planning helper returns, and the current helper-versus-judgment boundary.

--- a/skills/pcf-and-web-resources/SKILL.md
+++ b/skills/pcf-and-web-resources/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pcf-and-web-resources
+description: >
+  Use for Power Apps component framework (PCF) controls, model-driven web resources, client
+  form scripts, and Power Fx formula review. Covers scaffolding a PCF control, binding it to a
+  form control, building and deploying it through a wrapper solution or direct push, and keeping
+  the manifest version in sync with the wrapper-solution version. Also covers single and batch
+  JavaScript/HTML/CSS/XML/image web resource sync and publish, OnLoad/OnSave/OnChange form
+  handler registration, and Xrm.WebApi client code. Trigger this whenever the user mentions PCF,
+  pcfproj, ControlManifest, `pac pcf`, web resources, form scripts, ribbon JavaScript rules,
+  Xrm/formContext, or wants a Power Fx / canvas formula debugged — even if no helper is named.
+---
+
+# PCF and Web Resources
+
+This skill owns the client-side and field-rendering surfaces of a model-driven app: PCF code components, authored web resources (JavaScript, HTML, CSS, XML, images), client form scripts, and Power Fx formula review. Prefer the lightest surface that satisfies the requirement — a named form-script handler or a small web resource before a PCF control, and a PCF control before a heavy HTML web resource. Keep everything source-controlled and deploy through targeted helpers, not whole-solution import.
+
+## When to use this
+
+- Scaffold, implement, version, or deploy a PCF field or dataset control.
+- Bind a deployed PCF control to a specific form control.
+- Add or update an OnLoad / OnSave / OnChange form script or a ribbon `CustomRule` JavaScript function.
+- Sync and publish one web resource, or a batch of changed web resources.
+- Review or debug a Power Fx formula for delegation risk, missing `IfError`, or maintainability.
+
+For tables, columns, form metadata, or RibbonDiffXml structure, use `dataverse-schema`. For plug-ins, custom APIs, or shared server logic, use `plugins-server-extensions`. For a full pro-code SPA, use `code-apps`.
+
+## Helpers
+
+Helpers live in the plugin's `scripts/` directory at the plugin root, not inside this skill folder. Resolve the plugin root and invoke them:
+
+- Claude Code: `python "$CLAUDE_PLUGIN_ROOT/scripts/scaffold_pcf_control.py" --help`
+- Codex: `python "$CODEX_PLUGIN_ROOT/scripts/scaffold_pcf_control.py" --help` (also exposed as `$PLUGIN_ROOT`)
+- Standalone / unsure: the `scripts/` folder sits beside this skill bundle; invoke by its path within the install.
+
+| Helper | Use it to |
+| --- | --- |
+| `scaffold_pcf_control.py` | Create a new control (`--template field` or `--template dataset`) in the inferred or explicit PCF area, keeping the namespace aligned with the publisher prefix. |
+| `version_pcf_solution.py` | Bump both version surfaces together — the 3-part `version` in `ControlManifest.Input.xml` and the 4-part version in the wrapper `Solutions\src\Other\Solution.xml`. |
+| `deploy_pcf.py` | In `auto` mode: install dependencies, build, and either package-import the wrapper solution or fall back to direct `pac pcf push`. |
+| `bind_pcf_control.py` | Attach a deployed control to an existing form control through a headless `systemform.formxml` update when the binding is deterministic. |
+| `sync_webresource.py` | Headlessly upload/update and publish a single JS/HTML/CSS/XML/image web resource. |
+| `sync_webresources_batch.py` | Sync/publish several changed web resources in one pass — stop if the batch sweeps in unrelated files. |
+| `debug_power_fx.py` | Heuristic Power Fx review: function inventory, delegation-risk checks, missing-`IfError` on writes, maintainability warnings, rewrite hints, and test cases. |
+
+## Workflow
+
+1. **Pick the surface.** Form-scoped behavior → named form-script handler. Reusable input/visualization or dataset rendering → PCF. Focused static UI → small HTML/CSS web resource. Never introduce a Business Rule; never add unsupported DOM coupling to the page.
+2. **PCF — scaffold and implement.** Use `scaffold_pcf_control.py`; design for empty, loading, error, and disabled states; preserve accessibility and keyboard behavior; do not introduce a second frontend toolchain if the repo already standardizes one.
+3. **PCF — version before deploy.** Run `version_pcf_solution.py` so the manifest and wrapper-solution versions move together. Mismatched versions are the most common cause of a control that imports but does not update.
+4. **PCF — build, then deploy.** `deploy_pcf.py` in `auto` mode after a local build. If the repo has a wrapper `Solutions` project, treat it as the deployable package path: `Debug` artifacts come from `Solutions\bin\Debug`, `Release` (often managed + unmanaged) from `Solutions\bin\Release` — prefer the managed artifact unless the user asks for unmanaged.
+5. **PCF — bind.** When the form control target is known, run `bind_pcf_control.py`; otherwise report the remaining maker step.
+6. **Web resources.** Edit the authored source, then `sync_webresource.py` (one file) or `sync_webresources_batch.py` (several). For ribbon visibility/enablement, prefer a JavaScript `CustomRule` in a web resource over an XML `ValueRule`, and deploy the web resource only when the command already exists.
+7. **Form scripts.** Use `executionContext.getFormContext()` for new code; register only named exported functions with the expected signature; prefer `Xrm.WebApi` (`retrieveRecord`, `retrieveMultipleRecords`, `createRecord`, `updateRecord`, `execute`) selecting only the logical-name fields you need.
+8. **Power Fx.** Use `debug_power_fx.py` as a reviewer, not a compiler. Never claim a formula is delegation-safe unless the underlying connector and data source are known.
+
+## Safety and decision rules
+
+- Before any live mutation — web resource publish, PCF push/import, form metadata update — run the **mandatory live-mutation preflight from the `powerplatform-core` orchestrator** and stop if any required field is missing.
+- Keep manifest and wrapper-solution versions in sync on every PCF deploy. Do not ship one without the other unless the repo clearly uses a different convention.
+- Do not import a PCF wrapper ZIP from `bin`, `Release`, `Downloads`, or an old temp folder unless it was built in the current session or explicitly selected. If multiple package candidates exist, stop and ask.
+- Never silently escalate a targeted web-resource or form change into a whole-solution import. If the change exceeds the targeted helper surface (entity-level command bar, new button/command, new display rule), say so and ask before broadening the blast radius.
+- After a command-bar or ribbon-JS change, verify behavior on the real grid (hard refresh, clear command-bar cache, test the show/hide matrix) and read back the metadata — do not trust import output alone.
+- Do not hard-code environment URLs or tenant-specific values into web resources or controls.
+- Report what was built, versioned, deployed, and verified, and which publish/import/bind steps still need environment access.
+
+## References
+
+- `references/pcf-controls.md` — PCF design, scaffolding, wrapper-solution packaging, dual-surface versioning, and validation.
+- `references/client-customization.md` — form scripts, client APIs, ribbon JavaScript rules, and HTML/CSS/JS/TS web resources.
+- `references/power-fx.md` — formula debugging, delegation review, and rewrite guidance.

--- a/skills/plugins-server-extensions/SKILL.md
+++ b/skills/plugins-server-extensions/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: plugins-server-extensions
+description: >
+  Use for ANY Dataverse server-side extension task — C# plug-ins and custom APIs. Covers
+  headless first registration of a plug-in assembly or plug-in package, repeatable build-and-
+  push, SDK message-processing step and image inspection, reconciling step enable/disable
+  state to match source intent, and creating a custom API with its request parameters and
+  response properties. Fires whenever the user mentions a plug-in, plugin step, SDKMessage,
+  pre/post image, plug-in assembly or package, "register my plug-in", "push the plug-in",
+  "why is my step disabled", step-state drift, or a custom API / unbound action backed by a
+  plug-in — even if no helper is named. Treats step enablement as explicit deployment state
+  and registration as a separate approval gate. Run the live-mutation preflight from the
+  `powerplatform-core` orchestrator before any registration, push, or step-state write.
+---
+
+# Plug-Ins & Server Extensions
+
+This skill handles Dataverse server-side logic — C# plug-ins and custom APIs — with a code-first, headless-first posture. It registers and pushes plug-in assemblies and plug-in packages, inspects SDK message-processing steps and images, reconciles step enable/disable state against source intent, and creates custom APIs with their parameters and properties. It treats step enablement as explicit deployment state and registration as an approval gate separate from build, even when code creation and build were already approved. It is intentionally generic about environment URL, publisher prefix, solution name, and project layout — read or request them per task and preserve any existing layered `*.Business`/`*.Data`/`*.Plugins` delivery model.
+
+## When to use this
+
+- The user wants to register, push, or update a plug-in (assembly or package) and its steps/images.
+- A step needs inspecting, or its enabled/disabled state must be reconciled to match what the source intends.
+- You are diagnosing step-state drift after a push, registration, or solution import.
+- The user wants a custom API (bound or unbound) created, optionally backed by a plug-in.
+- You need to confirm critical steps stayed enabled and intentionally disabled steps stayed disabled.
+
+Route here from the `powerplatform-core` orchestrator. For flows, schema, PCF/web resources, or solution packaging, use the matching sibling skill instead.
+
+## Helpers
+
+The helpers live in the plugin's `scripts/` directory at the plugin root, not in this skill folder. Resolve the plugin root and invoke them like:
+
+- `python "$CLAUDE_PLUGIN_ROOT/scripts/inspect_plugin_steps.py" --spec <spec.json>` (Claude Code)
+- `python "$CODEX_PLUGIN_ROOT/scripts/inspect_plugin_steps.py" --spec <spec.json>` (also exposed as `$PLUGIN_ROOT`)
+- Installed standalone / unsure: the `scripts/` folder sits beside this skill bundle — invoke by its path within the install.
+
+| Helper | Purpose |
+| --- | --- |
+| `register_plugin_headless.py` | Assembly-based first registration of a Dataverse plug-in assembly plus its steps and images, via `pluginassembly`, `plugintype`, `sdkmessageprocessingstep`, and `sdkmessageprocessingstepimage`. |
+| `register_plugin_package_headless.py` | Package-based first registration of a Dataverse plug-in package plus steps and images, via `pluginpackage` and the related server-managed `pluginassembly`/`plugintype` records. |
+| `push_plugin.py` | Repeatable build-and-push when the target `pluginId` already exists; captures step state before, compares after, and fails on unexpected drift unless reconcile is requested. |
+| `inspect_plugin_steps.py` | Inspect existing step state for an assembly or package — messages, stages, modes, filtering attributes, images, and enabled/disabled state. |
+| `ensure_plugin_step_state.py` | Explicitly enable or disable existing steps so live state matches source intent (`desiredState`). |
+| `create_custom_api.py` | Repeatable headless creation of a custom API plus its request parameters and response properties. |
+
+## Domain workflow
+
+1. **Build.** Restore and build the plug-in solution. Keep trigger/entry-point classes in `*.Plugins` thin, reusable business logic in the business layer, and early-bound types in the generated `*.Data` (generator-owned — do not hand-edit).
+2. **Capture baseline state.** Before any push or re-registration of an existing plug-in, run `inspect_plugin_steps.py` so you have the pre-change step/image picture to compare against.
+3. **Register or push (separate approval gate).**
+   - First registration: `register_plugin_headless.py` (assembly) or `register_plugin_package_headless.py` (package). Official Microsoft guidance still centers first registration on the Plug-in Registration Tool (`pac tool prt`); headless is offered for automation when you confirm the targets.
+   - Repeatable update when `pluginId` exists: `push_plugin.py`.
+   - Ask before registration or push even if code and build were approved.
+4. **Verify step state.** Re-run `inspect_plugin_steps.py` (or rely on `push_plugin.py`'s post-push check) and confirm critical steps stayed enabled and intentionally disabled steps stayed disabled. Treat unexpected drift as a failure.
+5. **Reconcile if needed.** Use `ensure_plugin_step_state.py` with an explicit `desiredState` to bring steps back to source intent. Do not rely on push/registration to preserve enable/disable state implicitly.
+6. **Custom APIs.** Define unique name, bound/unbound behavior, request parameters, response properties, backing plug-in, and visibility/security first, then create with `create_custom_api.py`. Prefer a plug-in-backed custom API when business logic or validation belongs on the server.
+
+## Safety and decision rules
+
+- **Registration is a separate approval gate.** Building and pushing are distinct steps; ask before registration or push, and never register steps blindly.
+- **Step enablement is explicit deployment state.** Always verify it after registration, push, or solution import. Encode stable critical or intentionally disabled steps in the project profile rather than relying on memory.
+- **Fail on drift by default.** `push_plugin.py` compares step state before and after and fails on unexpected drift unless the user explicitly asks for reconcile.
+- **Runtime assumption.** Dataverse guidance currently requires SDK-style plug-in projects targeting `.NET Framework 4.6.2`; verify current Microsoft docs before changing it.
+- **Packaging.** Prefer the supported plug-in package approach over `ILMerge` when dependent assemblies are needed, and preserve an existing layered/ILRepack delivery model unless the user asks to redesign it.
+- **Generated code is generator-owned.** Do not hand-edit `*.Data` early-bound files; change generator settings or regenerate instead.
+- **Preflight gate.** Run the mandatory live-mutation preflight from the `powerplatform-core` orchestrator before any registration, push, or step-state write. Do not restate the full preflight here — invoke it there.
+
+## References
+
+- `references/server-extensions.md` — plug-in baseline, registration automation position, custom APIs, early-bound code, and validation checklist.

--- a/skills/power-automate-flows/SKILL.md
+++ b/skills/power-automate-flows/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: power-automate-flows
+description: >
+  Use for ANY solution-aware Power Automate cloud flow task in Dataverse — create, update,
+  inspect, lint, connector governance review, hardening review (retry/concurrency/pagination/
+  idempotency/error handling), HTTP-trigger callback URL resolution, and the environment
+  variables that flows read. Fires whenever the user mentions a cloud flow, Power Automate,
+  a workflow record, flow connection references, a flow trigger URL or webhook callback,
+  "lint my flow", "harden this flow", "review the connectors", or "why did my flow change
+  behavior" — even if no helper is named. Updates only the changed `workflow` properties and
+  treats semantic drift (emptied branches, dropped switch cases, removed required actions) as
+  a blocker by default. Run the live-mutation preflight from the `powerplatform-core`
+  orchestrator before any create, update, activate, or environment-variable write.
+---
+
+# Power Automate Flows — Solution-Aware Cloud Flows
+
+This skill handles solution-aware Power Automate cloud flows as first-class Dataverse `workflow` records (`category = 5`). It inspects, lints, and reviews live flows, then makes the smallest correct change — patching only the `workflow` properties that need to move — and resolves HTTP-trigger callback URLs and the environment variables flows depend on. It is code-first and ALM-aware: live edits are for authoring and validation, while cross-environment promotion stays in the solution export/import path with connection references and environment variables kept explicit. It is intentionally generic about environment URL, publisher prefix, solution name, and folder layout — discover those per task.
+
+## When to use this
+
+- The user wants to create, update, or analyze a cloud flow, or asks you to "look at", "fix", "enhance", or "troubleshoot" one.
+- The task asks for a lint pass, a connector governance review, or a hardening review (retry policy, concurrency, pagination, idempotency, error handling, maintainability).
+- An HTTP-trigger flow needs its signed callback URL resolved, stored in an environment variable, or smoke-tested.
+- A flow reads an environment variable whose value must be inspected or set for the target environment.
+- You must guard a critical flow against losing a switch case, branch, or required action during an edit.
+
+Route here from the `powerplatform-core` orchestrator. For schema, plug-ins, PCF, or solution packaging, use the matching sibling skill instead.
+
+## Helpers
+
+The helpers live in the plugin's `scripts/` directory at the plugin root, not in this skill folder. Resolve the plugin root and invoke them like:
+
+- `python "$CLAUDE_PLUGIN_ROOT/scripts/inspect_flow.py" --spec <spec.json>` (Claude Code)
+- `python "$CODEX_PLUGIN_ROOT/scripts/inspect_flow.py" --spec <spec.json>` (also exposed as `$PLUGIN_ROOT`)
+- Installed standalone / unsure: the `scripts/` folder sits beside this skill bundle — invoke by its path within the install.
+
+| Helper | Purpose |
+| --- | --- |
+| `inspect_flow.py` | Inspect one flow or list solution-scoped flows; return identifiers, state, connection-reference summary, and definition summary. |
+| `lint_flow.py` | Detect missing connection references, missing triggers/actions, broken `runAfter`, hardcoded GUIDs, and hardcoded Dataverse URLs. Works from live Dataverse or a local `clientData`/`definition`/JSON file. |
+| `review_flow_connectors.py` | Review connector-specific read/write patterns (Dataverse, SharePoint, Outlook action shapes). Same live-or-local sources as the linter. |
+| `review_flow_hardening.py` | Hardening checklist for retry policy, concurrency, pagination, idempotency, error handling, and maintainability. Same live-or-local sources. |
+| `create_flow.py` | Create a new solution-aware flow from `clientData`, or from `definition` plus `connectionReferences`; add it to the selected solution. New flows start draft/off unless `activate` is set. |
+| `update_flow.py` | Update an existing flow by `workflowId`, `workflowUniqueId`, `uniqueName`, or `name`. When `clientData` is supplied, it inspects the live baseline, runs semantic regression checks, updates, then re-inspects the live result. Auto-loads a repo flow-guard contract. |
+| `get_flow_trigger_url.py` | Resolve the signed callback URL for an HTTP-trigger flow. **Windows-only / optional:** depends on Windows PowerShell plus the PowerApps admin module, and may prompt for a separate Power Apps sign-in. Skip gracefully where unavailable and tell the user. |
+| `inspect_environment_variable.py` | Inspect an environment variable definition or read the current value that applies in the target environment. |
+| `set_environment_variable_value.py` | Create or update the live `environmentvariablevalue` record for an existing definition. Prefer this over manual maker-portal edits when wiring a flow endpoint or environment-specific value. |
+
+## Domain workflow
+
+1. **Inspect first.** Run `inspect_flow.py` whenever the user wants to analyze, troubleshoot, or enhance a flow, so you work from the live baseline rather than assumptions.
+2. **Lint before large edits.** Run `lint_flow.py` to catch missing connection references, broken `runAfter`, hardcoded GUIDs, and hardcoded Dataverse URLs.
+3. **Review when quality matters.** Run `review_flow_hardening.py` for retry/concurrency/pagination/idempotency/error-handling concerns and `review_flow_connectors.py` for connector-specific patterns.
+4. **Change only what must change.** Use `update_flow.py` and patch only the `workflow` properties that need to move (typically `clientData`, plus name/description/owner/state). Prefer `create_flow.py` only for genuinely new flows. Do not recreate a flow to deploy it.
+5. **Resolve and wire HTTP triggers.** For an HTTP-trigger flow: create/update the flow, resolve the signed URL with `get_flow_trigger_url.py`, store it with `set_environment_variable_value.py`, then smoke-test only if the user asked. `apply_requirement_spec.py` can orchestrate this chain.
+6. **Promote through solution ALM.** Keep the flow in the selected unmanaged solution and promote via solution export/import with connection references and environment variables — not by re-authoring per environment.
+
+## Safety and decision rules
+
+- **Semantic drift is a blocker by default.** `update_flow.py` blocks updates that empty a previously non-empty switch case, remove previously existing branch actions, or violate a repo-owned flow-guard contract. Only pass `--allow-semantic-drift` when the branch/action removal is genuinely intended and the user accepts it.
+- **Keep a flow-guard contract for critical flows.** `update_flow.py` auto-loads a guard contract from the repo's flow-guard path or the project-profile `flowGuardSpecPath`. For critical flows, add a real contract in the repo rather than leaving the safeguard only in chat. Start from `references/power-platform.flow-guards.template.json`.
+- **Keep environment-specific values out of the definition.** Use connection references and environment variables; do not hardcode URLs or GUIDs into the flow definition.
+- **Do not delete flows** unless the user explicitly requests it. Ask before any publish/import step that affects the environment.
+- **Mind the dual auth surfaces.** Dataverse and the Power Apps admin surface use separate auth stacks, so trigger-URL retrieval can trigger one extra Power Apps sign-in prompt.
+- **Preflight gate.** Run the mandatory live-mutation preflight from the `powerplatform-core` orchestrator before any create, update, activate, or environment-variable write. Do not restate the full preflight here — invoke it there.
+
+## References
+
+- `references/power-automate-flows.md` — working model, preferred execution path, helper intent, and spec patterns.
+- `references/queries-and-xml.md` — Power Automate Dataverse queries, OData, and FetchXML inside flow actions.
+- `references/power-platform.flow-guards.template.json` — starting template for a repo flow-guard contract protecting critical switch branches.

--- a/skills/powerplatform-core/SKILL.md
+++ b/skills/powerplatform-core/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: powerplatform-core
+description: >
+  Use for ANY Microsoft Power Platform or Dataverse development task — model-driven apps,
+  plug-ins, PCF controls, web resources, form and ribbon metadata, solution-aware Power
+  Automate flows, Dataverse tables/columns/relationships, configuration data, custom APIs,
+  security roles, document generation, or solution ALM. Start here to discover repo context,
+  choose the right development surface, and safely build, validate, and deliver
+  source-controlled changes behind a mandatory live-mutation preflight. Trigger this whenever
+  the user mentions Power Platform, Dataverse, Dynamics 365, Power Apps, Power Automate,
+  model-driven apps, solutions, plug-ins, PCF, web resources, or the pac CLI — even if they
+  do not name a specific helper or file.
+---
+
+# Power Platform Core — Orchestrator
+
+PowerPlatform-Core is a code-first coding-agent skill for Microsoft Power Platform and Dataverse development. This orchestrator is the entry point: it discovers repo context, routes to the right domain skill, and enforces the safety rules that every domain shares. It is intentionally generic — it does not assume one house repo convention, environment URL, publisher prefix, or folder layout.
+
+Prefer executable, source-controlled surfaces (JavaScript, plug-ins, custom APIs, supported metadata APIs, SDK/Web API helpers, PAC CLI, repo-owned deploy wrappers) over Business Rules, portal memory, browser automation, or stale solution packages.
+
+## How it works
+
+1. **Discover first.** Run the discovery helper before asking broad setup questions; infer the project shape from existing artifacts (solutions, plug-ins, PCF, pipelines, project profile).
+2. **Choose the surface.** Pick the lightest surface that fits — metadata, client script, plug-in, custom API, flow, PCF, web resource, config data, or solution ALM — then open the matching domain skill.
+3. **Apply repo-backed changes first** so the result is source-controlled and reviewable.
+4. **Run the live-mutation preflight** before any deploy, publish, import, registration, push, or data write.
+5. **Validate and deliver through the approved targeted path** unless the user explicitly accepts a broader blast radius.
+
+## Running the helper scripts
+
+The Python helpers and the compiled `CodexPowerPlatform.DataverseOps` / `CodexPowerPlatform.AuthDialog` tools live in the plugin's **`scripts/`** and **`tools/`** directories at the plugin root — *not* inside each skill folder. Resolve the plugin root and invoke a helper like this:
+
+- **Claude Code:** `python "$CLAUDE_PLUGIN_ROOT/scripts/discover_context.py" --path .`
+- **Codex:** `python "$CODEX_PLUGIN_ROOT/scripts/discover_context.py" --path .` (also exposed as `$PLUGIN_ROOT`)
+- **Installed as a standalone skill / unsure:** the `scripts/` and `tools/` folders sit beside this skill bundle; invoke them by their path within the install.
+
+Shared references that several domains use (surface selection, verification, ALM, archetypes) live in the plugin's **`references/`** directory; domain skills point to the specific files they need.
+
+## Mandatory live-mutation preflight
+
+Before any live Dataverse mutation, print or capture a preflight gate. Use `scripts/validate_delivery.py --preflight-spec ...` when it fits; otherwise produce the same fields manually and stop if any required field is missing.
+
+Required fields: target environment URL; active PAC profile and mismatch warning when PAC is involved; target solution unique name and whether it is a patch; mutation type; exact components touched; delivery primitive; for any ZIP/package — artifact path, creation/modification time, solution name/version, managed state, and component diff; blast radius (targeted, component subset, patch package, or full solution); rollback/recovery plan; timeout and fallback path; and explicit confirmation when the primitive is not targeted.
+
+Do not import a ZIP from `bin`, `Release`, `Downloads`, or old temp folders unless it was generated in the current session or explicitly selected by the user. If multiple package candidates exist, stop and ask. Never silently escalate from a targeted helper to a whole-solution import.
+
+## Route to the right domain skill
+
+| The task is about… | Open skill |
+| --- | --- |
+| Tables, columns, relationships, forms, views, ribbon, icons, schema design | `dataverse-schema` |
+| Row create/update/upsert, query design (OData/FetchXML/Power Automate) | `data-operations` |
+| Solution-aware cloud flows: create, update, inspect, lint, connector/hardening review, trigger URLs | `power-automate-flows` |
+| Plug-ins, custom APIs, step registration, plug-in step state | `plugins-server-extensions` |
+| PCF controls, web resources, client scripts, Power Fx | `pcf-and-web-resources` |
+| Power Apps Code Apps (pro-code SPA model) | `code-apps` |
+| Solution pack/import/deploy, versioning, patch/merge, components, standards, delivery validation | `solution-alm-delivery` |
+| Security roles and privilege sets | `security-roles` |
+| Word Templates and document generation | `document-generation` |
+| Custom connectors and integration wrappers | `custom-connectors` |
+
+When a repo matches a documented overlay's conventions, suggest the specialized overlay skill if one is installed.
+
+## Discovery and project context
+
+- Run `scripts/discover_context.py --path .` first when the repo shape is not obvious. Add `--include-pac-auth` only when live access matters and PAC CLI is available.
+- If the repo has `.codex/power-platform.project-profile.json` or `power-platform.project-profile.json`, treat that profile as the first override layer for main solution, source areas, and conventions. If it has a `deploymentDefaults` block, treat those values as the repo's operational deploy guidance (timeout budgets, manual-only surfaces, preferred primitives, plug-in step-state defaults, typed row-write coercion). See `references/project-profile.md`.
+- If the repo matches a layered structure (`*.Business`, `*.Plugins`, `*.Data`, `WebResources`, `*.PCF`, `Word Templates`, `Dataverse`, `Tools`), follow that layout — see `references/repo-archetypes.md`.
+- Open `references/execution-surface-guide.md` to choose between metadata, client script, plug-ins, custom APIs, flows, web resources, or PCF.
+- Open `references/verification-and-recovery.md` for live-mutation work, deployment, or a precise completion standard before execution starts.
+- Open `references/context-and-alm.md` for auth, source-control layout, `pac` workflows, and environment safety.
+- For durable multi-session work, keep `README.md` and `CODEX_HANDOFF.md` current — see `references/thread-continuity.md`.
+
+## Default operating assumptions
+
+- For live SDK/Web API work, prefer the reusable auth dialog (`scripts/auth_context.py`) so the user confirms the target URL, completes a forced interactive sign-in, and selects the working solution before execution. The dialog is Windows-only; on macOS/Linux, sign-in uses the device-code flow (the tool prints a code to complete in a browser). Use `pac auth interactive` when the dialog is unavailable.
+- Warn when the requested live target does not match the active PAC profile environment URL. Treat `DEV` as the working environment and `TEST` as deployment validation. Do not touch production.
+- Ask before delete, import, publish, register, push, or upgrade. Do not delete business data unless explicitly requested and separately approved.
+- Keep every change solution-scoped (add/update only the scoped components in the target unmanaged solution or selected patch) — this does not mean defaulting to solution import.
+- Do not introduce Dataverse Business Rules. Use client script for form-scoped behavior and plug-ins or custom APIs for shared server-side behavior.
+- Treat plug-in step enablement as explicit deployment state: after registration/push/import, verify critical steps stay enabled and intentionally disabled steps stay disabled.
+- Treat browser automation as opt-in fallback only, after headless options are exhausted.
+- Report exactly what changed, what was inferred, what was executed, what was verified, what still needs environment access, and which publish/import/registration steps were intentionally not performed.
+
+## Closing out
+
+Validate the narrowest relevant surface, prefer small reviewable diffs over large repacks, and never describe a change as "deployed" or "complete" beyond what was actually verified. If critical inputs are missing (environment URL, solution name, publisher prefix, managed strategy, target folder), ask concise questions instead of guessing.

--- a/skills/security-roles/SKILL.md
+++ b/skills/security-roles/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: security-roles
+description: >
+  Use for ANY Dataverse security role task — list or inspect roles, create custom roles, and
+  update privilege sets or role metadata as code-first desired state. Fires whenever the user
+  says "create a security role", "give this role access", "update the privileges", "what can
+  this role do", "list the roles", "copy a role and adjust it", "set table permissions", or
+  asks about depth/scope (basic/local/deep/global), privilege names like `prvRead...`, or which
+  role a model-driven app needs — even if no helper is named. It is solution-aware and ALM-cautious:
+  it prefers custom roles over editing predefined or system-generated roles, copies a baseline
+  before adjusting, keeps role changes in the owning unmanaged solution, and warns about the
+  managed-import merge caveat where manually added privileges can be dropped. Run the live-mutation
+  preflight from the `powerplatform-core` orchestrator before any create or update.
+---
+
+# Security Roles — Dataverse Roles and Privilege Sets
+
+This skill handles Dataverse security role inspection, creation, and updates as reviewable, code-first desired state rather than ad hoc portal clicks. It lists and inspects roles (including their privilege sets and business unit), creates custom roles — optionally seeded by copying a baseline role — and applies privilege-set and metadata deltas through structured JSON specs. It is solution-aware: when a role belongs to your app or managed delivery path, the change stays scoped to the owning unmanaged solution. It is intentionally generic about environment URL, business unit, publisher prefix, and solution name — discover those per task.
+
+## When to use this
+
+- The user wants to create a custom role, or copy an existing role and adjust it.
+- The user wants to inspect or list roles, confirm whether a role is system-generated, or read its current privilege set before editing.
+- A privilege set needs to change (add, remove, or replace privileges, adjust depth, or apply a record filter).
+- Role metadata needs updating (name, description, applies-to, core-table permission summary, inheritance mode, auto-assign).
+- You need to confirm the minimum privileges a model-driven app or solution feature requires before granting access.
+
+Route here from the `powerplatform-core` orchestrator. For broader solution packaging, versioning, or promotion of the owning solution, use the `solution-alm-delivery` sibling skill.
+
+## Helpers
+
+The helpers live in the plugin's `scripts/` directory at the plugin root, not in this skill folder. Resolve the plugin root and invoke them like:
+
+- `python "$CLAUDE_PLUGIN_ROOT/scripts/inspect_security_role.py" --spec <spec.json>` (Claude Code)
+- `python "$CODEX_PLUGIN_ROOT/scripts/inspect_security_role.py" --spec <spec.json>` (also exposed as `$PLUGIN_ROOT`)
+- Installed standalone / unsure: the `scripts/` folder sits beside this skill bundle — invoke by its path within the install.
+
+| Helper | Purpose |
+| --- | --- |
+| `inspect_security_role.py` | List solution-scoped or business-unit roles, or inspect one role in detail, through the shared SDK helper. Drive it with a `--spec` whose `mode` is `list` or `inspect`; set `includePrivileges` to pull the current privilege set. Use this before editing when the business unit, system-generated status, or current privileges are unclear. |
+| `create_security_role.py` | Create a custom role from a `--spec`. Use `copyFromRoleName`/`copyFromRoleId` to seed from a baseline, then layer `additionalPrivileges`; supplying `privileges` replaces the baseline with that full desired set. Set `solutionUniqueName` to add the role to the owning unmanaged solution. |
+| `update_security_role.py` | Update role metadata and privilege sets from a `--spec`. Select by `roleId` or by `name` plus a business-unit selector; apply `additionalPrivileges`, `removePrivileges`, or a full `privileges` replacement, plus metadata fields like `newName`, `description`, `appliesTo`, and `inheritanceMode`. |
+
+The shared SDK tool exposes the same surface as `securityrole --mode list|inspect|create|update`. Privilege specs are code-first: each entry carries `privilegeId` or `privilegeName`, a `depth` (`basic`, `local`, `deep`, `global`, or `record-filter`), and an optional `recordFilterId`.
+
+## Domain workflow
+
+1. **Inspect before editing.** Run `inspect_security_role.py` when the exact business unit is unclear, when you must confirm whether a role is system-generated, when you need the current privilege set for review, or when you need to confirm the role is already in the selected solution.
+2. **Prefer a baseline copy.** Do not assume a new role can start from zero privileges and still be usable. For app access, navigation, or standard Dataverse usage, copy an appropriate baseline role (`copyFromRole...`) and apply a small declarative delta, or include the required minimum privileges explicitly.
+3. **Create as code-first desired state.** Use `create_security_role.py` with a reviewable JSON spec. Set `solutionUniqueName` so the role ships through ALM, and prefer the same unmanaged solution for later updates to the same role.
+4. **Update with explicit deltas.** Use `update_security_role.py` with `additionalPrivileges`/`removePrivileges` for targeted changes, or a full `privileges` set when replacing the desired state. Treat privilege changes as configuration, not one-off UI clicks.
+5. **Validate the final state.** Inspect the role after the change, confirm the intended privilege names and depths, confirm whether the role and its privileges were added to the target unmanaged solution, and state whether user/team assignment was intentionally not performed.
+
+## Safety and decision rules
+
+- **Do not edit predefined or system-generated roles by default.** Copy the baseline first and manage the copy. Only modify a system-generated role when the user explicitly approves it.
+- **Keep app-owned roles in their solution.** If the role is app-owned, keep later updates in the same custom unmanaged solution so the desired state stays source-controlled and promotable.
+- **Mind the managed-import merge caveat.** Managed solution imports merge security-role privileges differently from many other component types: when a managed solution updates a role, manually added privileges can be removed while privilege-level changes are retained. Manage role updates through the owning solution rather than relying on out-of-band manual additions.
+- **Call out environment-only changes.** If the user asks for a one-off live security change with no solution ownership, state that the change is environment-only and not yet captured in ALM.
+- **Grant the minimum that works.** Start from an appropriate baseline or include the explicit minimum privileges; avoid over-granting global depth where local or basic suffices.
+- **Preflight gate.** Run the mandatory live-mutation preflight from the `powerplatform-core` orchestrator before any role create or update. Do not restate the full preflight here — invoke it there.
+
+## References
+
+- `references/security-roles.md` — default position, before-you-change checklist, privilege spec shape, create/update/inspect spec patterns, ALM and merge cautions, and the validation checklist.

--- a/skills/solution-alm-delivery/SKILL.md
+++ b/skills/solution-alm-delivery/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: solution-alm-delivery
+description: >
+  Use for ANY Dataverse solution ALM and safe-delivery task — pack/import/deploy a solution,
+  add solution components, solution versioning, patch/merge/upgrade planning, repo standards
+  review, and the safe-delivery validation that runs the live-mutation preflight gate. Fires
+  whenever the user says "deploy the solution", "import the solution", "pack and import",
+  "bump the solution version", "create a patch", "merge the patch", "upgrade the solution",
+  "add this component to the solution", "validate my delivery", "is my repo following
+  standards", or asks for a managed/unmanaged solution package — even if no helper is named.
+  This is the most safety-critical skill: it blocks stale-artifact imports, refuses to silently
+  escalate a targeted change into a whole-solution import, classifies blast radius before any
+  mutation, and treats solution import as a slow 10-30 minute path that needs explicit approval.
+  Always run the live-mutation preflight from the `powerplatform-core` orchestrator before any
+  pack-to-import, publish, or component write.
+---
+
+# Solution ALM & Delivery — Pack, Import, Deploy, and Safe Promotion
+
+This skill owns Dataverse solution application lifecycle management and the safe-delivery path: packing and importing an unpacked solution, running delivery validation behind the mandatory live-mutation preflight, adding scoped components to a solution, versioning, planning patch/merge/upgrade lifecycles, and reviewing the repo against solution and ALM standards. It is deliberately conservative — it prefers the narrowest delivery primitive, keeps every change solution-scoped, and never quietly broadens a targeted component update into a whole-solution import. It is intentionally generic about environment URL, publisher prefix, solution unique name, managed strategy, and folder layout — discover those per task rather than assuming a house convention.
+
+## When to use this
+
+- The user wants to pack, import, deploy, publish, or promote a solution, or convert it to managed.
+- The user wants to add a component (table, column, web resource, flow, role, and so on) to a target solution.
+- The solution version needs to be set or incremented locally, and optionally synced online.
+- The user is deciding between continuing a patch, creating a new patch, merging, upgrading, or promoting work back to the main unmanaged solution.
+- The user wants delivery validated before a live mutation, or wants the repo reviewed against solution/ALM standards.
+
+Route here from the `powerplatform-core` orchestrator. For the targeted single-asset deploy paths (web resources, plug-ins, PCF, form/ribbon metadata), use the matching sibling skill first — only escalate to a solution package when no targeted primitive fits and the user accepts the broader blast radius.
+
+## Helpers
+
+The helpers live in the plugin's `scripts/` directory at the plugin root, not in this skill folder. Resolve the plugin root and invoke them like:
+
+- `python "$CLAUDE_PLUGIN_ROOT/scripts/validate_delivery.py" --preflight-spec <spec.json>` (Claude Code)
+- `python "$CODEX_PLUGIN_ROOT/scripts/validate_delivery.py" --preflight-spec <spec.json>` (also exposed as `$PLUGIN_ROOT`)
+- Installed standalone / unsure: the `scripts/` folder sits beside this skill bundle — invoke by its path within the install.
+
+| Helper | Purpose |
+| --- | --- |
+| `validate_delivery.py` | Run safe delivery validation across repo, build, pack, and an optional read-only live preflight — without importing or mutating Dataverse. Pass `--preflight-spec` to emit the live-mutation preflight gate; add `--live-preflight` for a read-only WhoAmI connectivity check. Use this before any solution import. |
+| `deploy_solution.py` | Pack, optionally run Power Apps Checker, import, and publish a solution. Blocks stale artifacts unless `--artifact-generated-this-session` or `--explicit-artifact-selection` is set, and enforces a blast-radius guard via `--change-scope {targeted-component,solution-subset,whole-solution}`; broadening to a whole-solution import on a `--shared-unmanaged-environment` requires explicit `--allow-broad-import`. Honors lock-retry and `--max-runtime-seconds` budgets. |
+| `add_solution_components.py` | Add resolved components to a target solution through the shared SDK helper from a `--spec`. Adds only the scoped components named; does not pull in broad required components or subcomponents unless the spec/user accepts the expanded blast radius. |
+| `solution_version.py` | Set or increment the 4-part solution version in the unpacked `Other/Solution.xml` (`--version`, `--increment {build,revision}`, or explicit parts), and optionally sync the version online with `--online`. Bump the version before re-importing a package. |
+| `plan_solution_patch_merge.py` | Plan a patch/merge/upgrade workflow from structured solution context (`--spec`). Returns recommended strategy, target solution, next version, concrete next steps, and warnings when the chosen target does not line up with the selected patch or main solution. Planning only — local and safe. |
+| `review_solution_standards.py` | Review the repo against solution, ALM, and house-style standards (continuity docs, project profile, publisher-prefix quality, main-vs-supporting solution ambiguity, PCF manifest/wrapper version alignment, generator-owned `*.Data` boundaries, `Reference` vs `Dataverse` intent). Returns findings, severity, recommendations, and an overall risk level. Read-only. |
+
+## Domain workflow
+
+1. **Plan the lifecycle first.** If the user is choosing between continuing a patch, a new patch, merge, upgrade, or returning to the main solution, run `plan_solution_patch_merge.py` before touching the environment. Treat the selected live solution as authoritative for the session; if it is a patch, do not silently redirect work to the parent.
+2. **Audit component membership.** Before exporting a patch or packaging for validation, compare the expected issue-related components against live patch membership. Place missing scoped components with `add_solution_components.py`; do not add broad required subcomponents without accepting the wider blast radius.
+3. **Version before re-importing.** Use `solution_version.py` to bump the version before a fresh package. Never retry importing the same version of a stale package — bump or switch to a targeted update path.
+4. **Validate behind the preflight.** Run `validate_delivery.py` (with `--preflight-spec`) so the live-mutation gate is emitted and repo/build/pack evidence is gathered before any import.
+5. **Deploy only the approved primitive.** Use `deploy_solution.py` only after blast-radius approval, with `--change-scope` set honestly and a freshly generated artifact. If a narrower targeted primitive exists in a sibling skill, prefer it.
+6. **Verify at the narrowest true level.** After import/publish, confirm the intended component landed in the intended solution and app surface; run one focused live check if behavior changed. Do not call a change "deployed" beyond what was verified — see `references/verification-and-recovery.md`.
+
+## Safety and decision rules
+
+This skill restates only the most critical gates. For the full required-field list, run the mandatory live-mutation preflight from the `powerplatform-core` orchestrator before any pack-to-import, publish, or component write — do not reconstruct it ad hoc here.
+
+- **Block stale artifacts.** Do not import a ZIP from `bin`, `Release`, `Downloads`, or old temp folders unless it was generated in the current session or explicitly selected by the user. If multiple package candidates exist, stop and ask.
+- **No silent escalation.** Never quietly broaden a targeted helper into a whole-solution import. If the required change exceeds the targeted surface, stop, explain the limitation, and ask whether the user accepts the broader blast radius.
+- **Classify blast radius honestly.** Set `--change-scope` to the true scope (`targeted-component`, `solution-subset`, or `whole-solution`). Treat whole-solution import in a shared unmanaged environment as high risk because it can overwrite unrelated maker work — require explicit approval and `--allow-broad-import`.
+- **Solution import is the slow path.** When the primitive becomes solution import, stop and state that this is no longer a fast targeted deploy and commonly takes 10-30 minutes including import, publish, cache refresh, and verification — and what narrower path was unavailable.
+- **Respect import/publish locks.** If Dataverse reports another import or publish is already running, do not skip immediately. Use the helper retry window first; report failure only after the wait-and-retry path is exhausted.
+- **Keep it solution-scoped, not solution-default.** Add or update only the scoped components in the target unmanaged solution or selected patch. Solution-scoped does not mean defaulting to a full solution package.
+- **Ask before destructive lifecycle ops.** Do not merge, delete, clone, retire, or upgrade patches/solutions unless the user explicitly requests that lifecycle operation and approves it.
+
+## References
+
+- `references/solution-patches.md` — patch/merge/upgrade rules, planner inputs and intents, and the patch component audit before a TST export.
+- `references/solution-standards.md` — what the standards review covers, expected output shape, and the repo-convention operating rules.
+- `references/verification-and-recovery.md` — the completion standard, minimum evidence by layer, failure-recovery sequence, and the authority rules when repo and live Dataverse disagree.

--- a/tests/test_apply_requirement_spec.py
+++ b/tests/test_apply_requirement_spec.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import unittest
+import unittest.mock
 from pathlib import Path
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
@@ -163,6 +164,29 @@ class ApplyRequirementSpecTests(unittest.TestCase):
         self.assertEqual(captured["command"][timeout_index], "180")
         self.assertIn("--skip-step-state-verification", captured["command"])
         self.assertIn("--skip-step-state-reconcile", captured["command"])
+
+    def test_run_deploy_solution_helper_honors_zero_numeric_options(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_command(command: list[str], *, cwd: Path | None = None, check: bool = True) -> object:
+            captured["command"] = command
+            return type("Result", (), {"stdout": '{"success": true}'})()
+
+        with unittest.mock.patch.object(apply_requirement_spec, "run_command", side_effect=fake_run_command):
+            apply_requirement_spec.run_deploy_solution_helper(
+                {
+                    "lockRetries": 0,
+                    "lockWaitSeconds": 0,
+                    "maxRuntimeSeconds": 0,
+                },
+                repo=Path.cwd(),
+                connection={"environment_url": "https://contoso.crm.dynamics.com"},
+            )
+
+        command = captured["command"]
+        for flag in ("--lock-retries", "--lock-wait-seconds", "--max-runtime-seconds"):
+            self.assertIn(flag, command)
+            self.assertEqual(command[command.index(flag) + 1], "0")
 
 
 if __name__ == "__main__":

--- a/tests/test_debug_power_fx.py
+++ b/tests/test_debug_power_fx.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import debug_power_fx  # type: ignore
+
+
+def _has_in_operator_finding(formula: str) -> bool:
+    findings = debug_power_fx.find_delegation_risks(formula, debug_power_fx.extract_functions(formula))
+    return any(finding["code"] == "delegation-in-operator" for finding in findings)
+
+
+class DebugPowerFxDelegationInOperatorTests(unittest.TestCase):
+    def test_real_in_operator_is_detected(self) -> None:
+        self.assertTrue(_has_in_operator_finding('"a" in Accounts'))
+        self.assertTrue(_has_in_operator_finding("Filter(Accounts, Status exactin SelectedStatuses)"))
+
+    def test_in_inside_string_literal_does_not_false_positive(self) -> None:
+        self.assertFalse(_has_in_operator_finding('Notify("Saved in progress")'))
+        self.assertFalse(_has_in_operator_finding('Set(message, "logged in successfully")'))
+
+    def test_in_inside_quoted_column_name_does_not_false_positive(self) -> None:
+        # A display-name identifier such as 'Check in date' must not trigger.
+        self.assertFalse(_has_in_operator_finding("ThisItem.'Check in date'"))
+
+    def test_in_as_substring_of_identifier_does_not_false_positive(self) -> None:
+        self.assertFalse(_has_in_operator_finding("Set(invoiceTotal, 100)"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_register_plugin_package_headless.py
+++ b/tests/test_register_plugin_package_headless.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import register_plugin_package_headless as registrar  # type: ignore
+
+
+class RegisterPluginPackageHeadlessTests(unittest.TestCase):
+    def test_missing_nuspec_fields_do_not_set_none_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_path = Path(temp_dir) / "Plugin.csproj"
+            project_path.write_text("<Project />", encoding="utf-8")
+            package_path = Path(temp_dir) / "Plugin.1.0.0.nupkg"
+            package_path.write_text("placeholder", encoding="utf-8")
+
+            captured: dict[str, object] = {}
+
+            def fake_run_dataverse_tool(command: list[str], *, cwd: Path | None = None) -> object:
+                spec_index = command.index("--spec") + 1
+                captured["spec"] = json.loads(command[spec_index])
+                return type("Result", (), {"stdout": "{}"})()
+
+            with mock.patch.object(registrar, "repo_root", return_value=Path(temp_dir)), \
+                 mock.patch.object(registrar, "infer_plugin_project", return_value=project_path), \
+                 mock.patch.object(registrar, "infer_plugin_package_file", return_value=package_path), \
+                 mock.patch.object(
+                     registrar,
+                     "read_nuget_metadata",
+                     return_value={"id": None, "version": None, "title": None, "description": None},
+                 ), \
+                 mock.patch.object(
+                     registrar,
+                     "resolve_live_connection",
+                     return_value={
+                         "environment_url": "https://contoso.crm.dynamics.com",
+                         "username": "user@contoso.com",
+                         "tenant_id": None,
+                     },
+                 ), \
+                 mock.patch.object(registrar, "apply_selected_solution_to_spec", side_effect=lambda spec, _conn: spec), \
+                 mock.patch.object(registrar, "apply_plugin_step_state_defaults_to_registration_spec", side_effect=lambda spec, _contract: spec), \
+                 mock.patch.object(registrar, "load_plugin_step_state_contract", return_value={}), \
+                 mock.patch.object(registrar, "run_dataverse_tool", side_effect=fake_run_dataverse_tool), \
+                 mock.patch.object(
+                     sys,
+                     "argv",
+                     ["register_plugin_package_headless.py", "--spec", "{}", "--skip-pack"],
+                 ):
+                exit_code = registrar.main()
+
+        self.assertEqual(exit_code, 0)
+        spec = captured["spec"]
+        # A missing nuspec field must never be defaulted to None.
+        self.assertNotIn("uniqueName", spec)
+        self.assertNotIn("name", spec)
+        self.assertNotIn("version", spec)
+        for key, value in spec.items():
+            self.assertIsNotNone(value, msg=f"spec['{key}'] should not be None")
+
+    def test_present_nuspec_fields_populate_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_path = Path(temp_dir) / "Plugin.csproj"
+            project_path.write_text("<Project />", encoding="utf-8")
+            package_path = Path(temp_dir) / "Plugin.1.0.0.nupkg"
+            package_path.write_text("placeholder", encoding="utf-8")
+
+            captured: dict[str, object] = {}
+
+            def fake_run_dataverse_tool(command: list[str], *, cwd: Path | None = None) -> object:
+                spec_index = command.index("--spec") + 1
+                captured["spec"] = json.loads(command[spec_index])
+                return type("Result", (), {"stdout": "{}"})()
+
+            with mock.patch.object(registrar, "repo_root", return_value=Path(temp_dir)), \
+                 mock.patch.object(registrar, "infer_plugin_project", return_value=project_path), \
+                 mock.patch.object(registrar, "infer_plugin_package_file", return_value=package_path), \
+                 mock.patch.object(
+                     registrar,
+                     "read_nuget_metadata",
+                     return_value={"id": "Contoso.Plugins", "version": "1.0.0", "title": "Contoso Plugins", "description": "Desc"},
+                 ), \
+                 mock.patch.object(
+                     registrar,
+                     "resolve_live_connection",
+                     return_value={
+                         "environment_url": "https://contoso.crm.dynamics.com",
+                         "username": "user@contoso.com",
+                         "tenant_id": None,
+                     },
+                 ), \
+                 mock.patch.object(registrar, "apply_selected_solution_to_spec", side_effect=lambda spec, _conn: spec), \
+                 mock.patch.object(registrar, "apply_plugin_step_state_defaults_to_registration_spec", side_effect=lambda spec, _contract: spec), \
+                 mock.patch.object(registrar, "load_plugin_step_state_contract", return_value={}), \
+                 mock.patch.object(registrar, "run_dataverse_tool", side_effect=fake_run_dataverse_tool), \
+                 mock.patch.object(
+                     sys,
+                     "argv",
+                     ["register_plugin_package_headless.py", "--spec", "{}", "--skip-pack"],
+                 ):
+                exit_code = registrar.main()
+
+        self.assertEqual(exit_code, 0)
+        spec = captured["spec"]
+        self.assertEqual(spec["uniqueName"], "Contoso.Plugins")
+        self.assertEqual(spec["name"], "Contoso Plugins")
+        self.assertEqual(spec["version"], "1.0.0")
+        self.assertEqual(spec["description"], "Desc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_messaging.py
+++ b/tests/test_skill_messaging.py
@@ -7,40 +7,57 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def frontmatter(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return ""
+    parts = text.split("---", 2)
+    block = parts[1] if len(parts) >= 3 else ""
+    # Collapse whitespace so phrases that wrap across lines in a folded YAML
+    # scalar (description: >) still match as contiguous substrings.
+    return re.sub(r"\s+", " ", block)
+
+
 class SkillMessagingTests(unittest.TestCase):
     def test_core_skill_description_markets_power_platform_development(self) -> None:
-        skill_text = (REPO_ROOT / "SKILL.md").read_text(encoding="utf-8")
-        description = re.search(r"description:\s*(.+)", skill_text)
+        # The top-level SKILL.md pointer and the orchestrator skill both carry the
+        # marketing description as a folded YAML scalar, so assert against the
+        # whole frontmatter block rather than a single line.
+        for skill_path in (
+            REPO_ROOT / "SKILL.md",
+            REPO_ROOT / "skills" / "powerplatform-core" / "SKILL.md",
+        ):
+            fm = frontmatter(skill_path)
+            self.assertIn("Microsoft Power Platform", fm, msg=str(skill_path))
+            self.assertIn("Dataverse", fm, msg=str(skill_path))
+            self.assertIn("plug-ins", fm, msg=str(skill_path))
+            self.assertIn("PCF controls", fm, msg=str(skill_path))
+        # The top-level pointer specifically positions Core as a coding-agent skill.
+        self.assertIn("coding-agent skill", frontmatter(REPO_ROOT / "SKILL.md"))
 
-        self.assertIsNotNone(description)
-        description_text = description.group(1)
-        self.assertIn("Microsoft Power Platform and Dataverse development", description_text)
-        self.assertIn("coding-agent skill", description_text)
-        self.assertIn("plug-ins", description_text)
-        self.assertIn("PCF controls", description_text)
-
-    def test_core_readme_opens_with_plain_english_value(self) -> None:
+    def test_core_readme_markets_the_plugin(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        lowered = readme.lower()
+        self.assertIn("Microsoft Power Platform", readme)
+        self.assertIn("Dataverse", readme)
+        self.assertIn("coding-agent", lowered)
+        self.assertIn("preflight", lowered)
+        self.assertIn("## Install", readme)
+        self.assertIn("## The skills", readme)
 
-        self.assertIn(
-            "PowerPlatform-Core is a coding-agent skill for Microsoft Power Platform and Dataverse development.",
-            readme,
-        )
-        self.assertIn("## How It Works", readme)
-        self.assertIn("discover repo context", readme.lower())
-        self.assertIn("approved targeted paths", readme.lower())
-
-    def test_core_command_bar_guidance_prefers_javascript_rules(self) -> None:
-        skill_text = (REPO_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    def test_command_bar_guidance_prefers_javascript_rules(self) -> None:
+        schema_skill = (REPO_ROOT / "skills" / "dataverse-schema" / "SKILL.md").read_text(encoding="utf-8")
         client_reference = (REPO_ROOT / "references" / "client-customization.md").read_text(encoding="utf-8")
         execution_reference = (REPO_ROOT / "references" / "execution-automation.md").read_text(encoding="utf-8")
 
-        self.assertIn("JavaScript `CustomRule`", skill_text)
+        # The JavaScript-CustomRule-over-XML-ValueRule guidance now lives in the
+        # client-facing domain skill, while the reference files keep the canonical detail.
+        self.assertIn("JavaScript `CustomRule`", schema_skill)
+        self.assertIn("ValueRule", schema_skill)
         self.assertIn("Avoid XML `ValueRule`", client_reference)
+        self.assertIn("do not try the form-ribbon helper first", client_reference)
         self.assertIn("RibbonDiffXml Recovery Path", execution_reference)
         self.assertIn("10-30 minute duration window", execution_reference)
-        self.assertIn("Entity command bar, new button, new command, or new display rule", skill_text)
-        self.assertIn("do not try the form-ribbon helper first", client_reference)
         self.assertIn("bump version before import", execution_reference)
 
 

--- a/tests/test_version_pcf_solution.py
+++ b/tests/test_version_pcf_solution.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
@@ -60,6 +61,29 @@ class VersionPcfSolutionTests(unittest.TestCase):
 
             self.assertIn('version="1.2.4"', manifest_path.read_text(encoding="utf-8"))
             self.assertIn("<Version>1.2.4.0</Version>", solution_path.read_text(encoding="utf-8"))
+
+    def test_main_errors_and_does_not_rewrite_when_no_version_or_increment(self) -> None:
+        pcf_context = {
+            "package_root": "pkg",
+            "pcf_project_file": "control.pcfproj",
+            "manifests": [{"manifest_path": "ControlManifest.Input.xml", "version": "1.2.3"}],
+            "solution_context": {"version": "1.2.3.4"},
+            "solution_xml": "Solution.xml",
+        }
+
+        with mock.patch.object(version_pcf_solution, "repo_root", return_value=Path(".")), \
+             mock.patch.object(version_pcf_solution, "resolve_pcf_context", return_value=pcf_context), \
+             mock.patch.object(version_pcf_solution, "update_manifest_version") as update_manifest, \
+             mock.patch.object(version_pcf_solution, "update_solution_version") as update_solution, \
+             mock.patch.object(version_pcf_solution, "write_json_output") as write_json_output, \
+             mock.patch.object(sys, "argv", ["version_pcf_solution.py"]):
+            with self.assertRaises(SystemExit) as raised:
+                version_pcf_solution.main()
+
+        self.assertNotEqual(raised.exception.code, 0)
+        update_manifest.assert_not_called()
+        update_solution.assert_not_called()
+        write_json_output.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tools/CodexPowerPlatform.AuthDialog/SolutionListProcessRunner.cs
+++ b/tools/CodexPowerPlatform.AuthDialog/SolutionListProcessRunner.cs
@@ -60,7 +60,20 @@ internal static class SolutionListProcessRunner
         process.Start();
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
         var stderrTask = process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync().ConfigureAwait(true);
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(true);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKillProcess(process);
+            return new SolutionListAttemptResult(
+                false,
+                "Solution lookup timed out after 120s.",
+                string.Empty,
+                Array.Empty<SolutionDialogOption>());
+        }
 
         var stdout = await stdoutTask.ConfigureAwait(true);
         var stderr = await stderrTask.ConfigureAwait(true);
@@ -111,5 +124,20 @@ internal static class SolutionListProcessRunner
     private static bool ReadBool(JsonObject node, string camelCase, string pascalCase)
     {
         return node[camelCase]?.GetValue<bool>() == true || node[pascalCase]?.GetValue<bool>() == true;
+    }
+
+    private static void TryKillProcess(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; the timeout result is the meaningful signal.
+        }
     }
 }

--- a/tools/CodexPowerPlatform.AuthDialog/TargetInputResolver.cs
+++ b/tools/CodexPowerPlatform.AuthDialog/TargetInputResolver.cs
@@ -90,7 +90,17 @@ internal static class TargetInputResolver
         process.Start();
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
         var stderrTask = process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync().ConfigureAwait(true);
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(true);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKillProcess(process);
+            throw new InvalidOperationException(
+                "PAC CLI 'env list' timed out after 120s while resolving the environment URL.");
+        }
 
         var stdout = await stdoutTask.ConfigureAwait(true);
         var stderr = await stderrTask.ConfigureAwait(true);
@@ -116,5 +126,20 @@ internal static class TargetInputResolver
 
         throw new InvalidOperationException(
             $"PAC CLI did not return an environment URL for environment ID '{environmentId}'.");
+    }
+
+    private static void TryKillProcess(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; the timeout error is the meaningful signal.
+        }
     }
 }

--- a/tools/CodexPowerPlatform.DataverseOps/CodexPowerPlatform.DataverseOps.csproj
+++ b/tools/CodexPowerPlatform.DataverseOps/CodexPowerPlatform.DataverseOps.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <!-- net8.0 is cross-platform (browser/device-code auth). net8.0-windows is added
+         on Windows only and carries the WAM broker. Keeps the Windows build identical
+         to before while enabling macOS/Linux hosts. -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net8.0;net8.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/tools/CodexPowerPlatform.DataverseOps/FormXmlPatchEngine.cs
+++ b/tools/CodexPowerPlatform.DataverseOps/FormXmlPatchEngine.cs
@@ -1,3 +1,4 @@
+using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
@@ -22,17 +23,16 @@ internal static class FormXmlPatchEngine
 {
     internal static XmlPatchApplicationResult ApplyFormXmlPatch(string formXml, IReadOnlyList<XmlPatchOperationSpec> operations)
     {
-        var document = XDocument.Parse(formXml, LoadOptions.PreserveWhitespace);
+        var document = LoadXmlDocument(formXml);
         var root = document.Root ?? throw new InvalidOperationException("Form XML does not contain a root form node.");
         var appliedOperations = new List<string>();
-        var createdNodes = new List<string>();
         var changed = ApplyOperations(root, operations, appliedOperations);
 
         return new XmlPatchApplicationResult(
             changed,
             document.ToString(SaveOptions.DisableFormatting),
             appliedOperations,
-            createdNodes);
+            new List<string>());
     }
 
     internal static XmlPatchApplicationResult ApplyFormRibbonPatch(
@@ -40,7 +40,7 @@ internal static class FormXmlPatchEngine
         IReadOnlyList<XmlPatchOperationSpec> operations,
         bool createRibbonDiffXmlIfMissing)
     {
-        var document = XDocument.Parse(formXml, LoadOptions.PreserveWhitespace);
+        var document = LoadXmlDocument(formXml);
         var root = document.Root ?? throw new InvalidOperationException("Form XML does not contain a root form node.");
         var appliedOperations = new List<string>();
         var createdNodes = new List<string>();
@@ -252,7 +252,7 @@ internal static class FormXmlPatchEngine
             throw new InvalidOperationException($"{operationType} requires a non-empty xml fragment.");
         }
 
-        var wrapper = XElement.Parse($"<root>{xml}</root>", LoadOptions.PreserveWhitespace);
+        var wrapper = LoadXmlDocument($"<root>{xml}</root>").Root!;
         if (!wrapper.Nodes().Any())
         {
             throw new InvalidOperationException($"{operationType} requires at least one XML element fragment.");
@@ -264,6 +264,20 @@ internal static class FormXmlPatchEngine
         }
 
         return wrapper.Elements().Select(element => new XElement(element)).ToList();
+    }
+
+    private static XDocument LoadXmlDocument(string xml)
+    {
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            MaxCharactersFromEntities = 0,
+            XmlResolver = null,
+        };
+
+        using var stringReader = new StringReader(xml);
+        using var xmlReader = XmlReader.Create(stringReader, settings);
+        return XDocument.Load(xmlReader, LoadOptions.PreserveWhitespace);
     }
 
     private static List<XElement> CloneElements(List<XElement> elements)

--- a/tools/CodexPowerPlatform.DataverseOps/Program.Metadata.Patching.cs
+++ b/tools/CodexPowerPlatform.DataverseOps/Program.Metadata.Patching.cs
@@ -30,7 +30,6 @@ internal static partial class Program
                 entityLogicalName = spec.EntityLogicalName,
                 formName = spec.FormName,
                 appliedOperations = updated.AppliedOperations,
-                createdNodes = updated.CreatedNodes,
                 message = "No form XML changes were needed.",
             };
         }
@@ -49,7 +48,6 @@ internal static partial class Program
             entityLogicalName = spec.EntityLogicalName,
             formName = spec.FormName,
             appliedOperations = updated.AppliedOperations,
-            createdNodes = updated.CreatedNodes,
         };
     }
 

--- a/tools/CodexPowerPlatform.DataverseOps/Program.Plugins.cs
+++ b/tools/CodexPowerPlatform.DataverseOps/Program.Plugins.cs
@@ -94,7 +94,7 @@ internal static partial class Program
         var requiredTypeNames = GetRequiredPluginTypeNames(spec.Steps);
         var pluginTypes = requiredTypeNames.Length == 0
             ? new Dictionary<string, Entity>(StringComparer.Ordinal)
-            : WaitForAssemblyPluginTypes(client, assemblyId, requiredTypeNames);
+            : WaitForAssemblyPluginTypes(client, assemblyId, requiredTypeNames, ResolvePluginTypeWaitSeconds(spec.PluginTypeWaitSeconds));
         var createdSteps = CreatePluginSteps(client, spec.SolutionUniqueName, pluginTypes, spec.Steps);
 
         var payload = new
@@ -164,7 +164,7 @@ internal static partial class Program
         var requiredTypeNames = GetRequiredPluginTypeNames(spec.Steps);
         var pluginTypes = requiredTypeNames.Length == 0
             ? new Dictionary<string, Entity>(StringComparer.Ordinal)
-            : WaitForPackagePluginTypes(client, packageId, requiredTypeNames);
+            : WaitForPackagePluginTypes(client, packageId, requiredTypeNames, ResolvePluginTypeWaitSeconds(spec.PluginTypeWaitSeconds));
         var createdSteps = CreatePluginSteps(client, spec.SolutionUniqueName, pluginTypes, spec.Steps);
 
         var payload = new
@@ -358,10 +358,16 @@ internal static partial class Program
         return createdSteps;
     }
 
+    private static int ResolvePluginTypeWaitSeconds(int? requestedWaitSeconds)
+    {
+        return requestedWaitSeconds is > 0 ? requestedWaitSeconds.Value : 60;
+    }
+
     private static Dictionary<string, Entity> WaitForAssemblyPluginTypes(
         ServiceClient client,
         Guid assemblyId,
-        IReadOnlyCollection<string> typeNames)
+        IReadOnlyCollection<string> typeNames,
+        int waitSeconds)
     {
         return WaitForPluginTypes(
             client,
@@ -370,13 +376,15 @@ internal static partial class Program
             {
                 query.Criteria.AddCondition("pluginassemblyid", ConditionOperator.Equal, assemblyId);
             },
-            "plug-in assembly");
+            "plug-in assembly",
+            waitSeconds);
     }
 
     private static Dictionary<string, Entity> WaitForPackagePluginTypes(
         ServiceClient client,
         Guid packageId,
-        IReadOnlyCollection<string> typeNames)
+        IReadOnlyCollection<string> typeNames,
+        int waitSeconds)
     {
         return WaitForPluginTypes(
             client,
@@ -386,16 +394,18 @@ internal static partial class Program
                 var assemblyLink = query.AddLink("pluginassembly", "pluginassemblyid", "pluginassemblyid", JoinOperator.Inner);
                 assemblyLink.LinkCriteria.AddCondition("packageid", ConditionOperator.Equal, packageId);
             },
-            "plug-in package");
+            "plug-in package",
+            waitSeconds);
     }
 
     private static Dictionary<string, Entity> WaitForPluginTypes(
         ServiceClient client,
         IReadOnlyCollection<string> typeNames,
         Action<QueryExpression> applyScope,
-        string registrationKind)
+        string registrationKind,
+        int waitSeconds)
     {
-        var deadline = DateTime.UtcNow.AddSeconds(30);
+        var deadline = DateTime.UtcNow.AddSeconds(waitSeconds);
         while (DateTime.UtcNow <= deadline)
         {
             var query = new QueryExpression("plugintype")
@@ -619,6 +629,8 @@ internal static partial class Program
 
         public string? SolutionUniqueName { get; init; }
 
+        public int? PluginTypeWaitSeconds { get; init; }
+
         public List<PluginStepRegistrationSpec> Steps { get; init; } = new();
     }
 
@@ -633,6 +645,8 @@ internal static partial class Program
         public string Version { get; init; } = string.Empty;
 
         public string? SolutionUniqueName { get; init; }
+
+        public int? PluginTypeWaitSeconds { get; init; }
 
         public List<PluginStepRegistrationSpec> Steps { get; init; } = new();
     }

--- a/tools/CodexPowerPlatform.DataverseOps/Program.SecurityRoles.cs
+++ b/tools/CodexPowerPlatform.DataverseOps/Program.SecurityRoles.cs
@@ -313,6 +313,7 @@ internal static partial class Program
     {
         var resolvedBusinessUnitId = ResolveBusinessUnitId(client, businessUnitId, businessUnitName, allowDefaultRoot: false);
         var query = BuildSecurityRoleQuery(solutionUniqueName, resolvedBusinessUnitId, includeSystemGenerated: true);
+        query.PageInfo = null;
         query.TopCount = 2;
 
         var selectorCount = 0;

--- a/tools/CodexPowerPlatform.DataverseOps/Program.cs
+++ b/tools/CodexPowerPlatform.DataverseOps/Program.cs
@@ -399,12 +399,20 @@ internal static partial class Program
 
     private static IPublicClientApplication BuildPublicClientApplication(string appId, string redirectUri, string tenantId)
     {
-        var app = PublicClientApplicationBuilder
+        var builder = PublicClientApplicationBuilder
             .Create(appId)
             .WithAuthority(AzureCloudInstance.AzurePublic, tenantId)
-            .WithRedirectUri(redirectUri)
-            .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows))
-            .Build();
+            .WithRedirectUri(redirectUri);
+
+        // The WAM broker is Windows-only. On Windows this branch is always taken, so
+        // sign-in is unchanged; on macOS/Linux we skip it and use the browser/device-code
+        // flows, which MSAL supports cross-platform.
+        if (OperatingSystem.IsWindows())
+        {
+            builder = builder.WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
+        }
+
+        var app = builder.Build();
 
         var cacheDirectory = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -412,9 +420,19 @@ internal static partial class Program
             "Dataverse");
         Directory.CreateDirectory(cacheDirectory);
 
-        var storageProperties = new StorageCreationPropertiesBuilder("msal_token_cache.bin", cacheDirectory).Build();
-        var cacheHelper = MsalCacheHelper.CreateAsync(storageProperties).GetAwaiter().GetResult();
-        cacheHelper.RegisterCache(app.UserTokenCache);
+        // Persistent token cache is best-effort. On Windows it uses DPAPI as before; on
+        // some Linux/macOS setups without a configured secret store the cache cannot be
+        // created, so we continue without persistence instead of failing the command.
+        try
+        {
+            var storageProperties = new StorageCreationPropertiesBuilder("msal_token_cache.bin", cacheDirectory).Build();
+            var cacheHelper = MsalCacheHelper.CreateAsync(storageProperties).GetAwaiter().GetResult();
+            cacheHelper.RegisterCache(app.UserTokenCache);
+        }
+        catch (Exception)
+        {
+            // No persistent token cache available on this host; tokens are re-acquired per run.
+        }
 
         return app;
     }
@@ -455,6 +473,11 @@ internal static partial class Program
         catch (MsalUiRequiredException)
         {
             Log(verbose, "MSAL silent token acquisition requires user interaction.");
+            return await AcquireInteractiveTokenAsync(publicClient, scope, username, authFlow, verbose, parentWindowHandle).ConfigureAwait(false);
+        }
+        catch (MsalServiceException ex)
+        {
+            Log(verbose, $"MSAL silent token acquisition failed ({ex.ErrorCode}); falling back to interactive sign-in.");
             return await AcquireInteractiveTokenAsync(publicClient, scope, username, authFlow, verbose, parentWindowHandle).ConfigureAwait(false);
         }
     }

--- a/verify_repo.py
+++ b/verify_repo.py
@@ -40,6 +40,7 @@ def main() -> int:
 
     if not args.skip_python:
         run_step("Python syntax", verify_python_sources)
+    run_step("Skill structure", verify_skill_structure)
     if not args.skip_tests:
         run_step("Unit tests", lambda: run_command([sys.executable, "-m", "unittest", "discover", "-s", "tests", "-v"]))
     if not args.skip_dotnet:
@@ -90,6 +91,36 @@ def iter_python_sources() -> list[Path]:
             sorted(path for path in directory.rglob("*.py") if "__pycache__" not in path.parts)
         )
     return paths
+
+
+def verify_skill_structure() -> None:
+    import json
+
+    skills_dir = ROOT / "skills"
+    if skills_dir.exists():
+        skill_files = sorted(skills_dir.glob("*/SKILL.md"))
+        if not skill_files:
+            raise RuntimeError("skills/ exists but contains no <name>/SKILL.md files.")
+        for path in skill_files:
+            text = path.read_text(encoding="utf-8")
+            if not text.startswith("---"):
+                raise RuntimeError(f"{path} is missing YAML frontmatter.")
+            frontmatter = text.split("---", 2)[1]
+            if "name:" not in frontmatter or "description:" not in frontmatter:
+                raise RuntimeError(f"{path} frontmatter must define both name and description.")
+            if f"name: {path.parent.name}" not in frontmatter:
+                raise RuntimeError(f"{path} frontmatter name must match its folder '{path.parent.name}'.")
+    for manifest in (
+        ROOT / ".claude-plugin" / "plugin.json",
+        ROOT / ".claude-plugin" / "marketplace.json",
+        ROOT / ".codex-plugin" / "plugin.json",
+        ROOT / ".agents" / "plugins" / "marketplace.json",
+    ):
+        if manifest.exists():
+            try:
+                json.loads(manifest.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(f"{manifest} is not valid JSON: {exc}") from exc
 
 
 def verify_dotnet_projects() -> None:

--- a/verify_repo.py
+++ b/verify_repo.py
@@ -11,11 +11,17 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
-DOTNET_PROJECTS = (
+IS_WINDOWS = os.name == "nt"
+# DataverseOps multi-targets net8.0 (+ net8.0-windows on Windows) and builds everywhere.
+CROSS_PLATFORM_DOTNET_PROJECTS = (
     ROOT / "tools" / "CodexPowerPlatform.DataverseOps" / "CodexPowerPlatform.DataverseOps.csproj",
+)
+# AuthDialog is a WPF (net8.0-windows) app; it only builds on Windows.
+WINDOWS_ONLY_DOTNET_PROJECTS = (
     ROOT / "tools" / "CodexPowerPlatform.AuthDialog" / "CodexPowerPlatform.AuthDialog.csproj",
 )
-DOTNET_TEST_PROJECTS = (
+# The .NET test project targets net8.0-windows.
+WINDOWS_ONLY_DOTNET_TEST_PROJECTS = (
     ROOT / "tools" / "CodexPowerPlatform.DataverseOps.Tests" / "CodexPowerPlatform.DataverseOps.Tests.csproj",
 )
 
@@ -90,7 +96,13 @@ def verify_dotnet_projects() -> None:
     dotnet = shutil.which("dotnet")
     if not dotnet:
         raise RuntimeError("dotnet was not found on PATH. Install the .NET SDK or rerun with --skip-dotnet.")
-    for project in DOTNET_PROJECTS:
+    projects = list(CROSS_PLATFORM_DOTNET_PROJECTS)
+    if IS_WINDOWS:
+        projects.extend(WINDOWS_ONLY_DOTNET_PROJECTS)
+    else:
+        for project in WINDOWS_ONLY_DOTNET_PROJECTS:
+            print(f"Skipping {project.name} (Windows-only WPF project) on this non-Windows host.")
+    for project in projects:
         run_command([dotnet, "build", str(project), "--nologo"])
 
 
@@ -98,22 +110,38 @@ def verify_dotnet_test_projects() -> None:
     dotnet = shutil.which("dotnet")
     if not dotnet:
         raise RuntimeError("dotnet was not found on PATH. Install the .NET SDK or rerun with --skip-dotnet.")
-    for project in DOTNET_TEST_PROJECTS:
+    if not IS_WINDOWS:
+        for project in WINDOWS_ONLY_DOTNET_TEST_PROJECTS:
+            print(f"Skipping {project.name} (net8.0-windows test project) on this non-Windows host.")
+        return
+    for project in WINDOWS_ONLY_DOTNET_TEST_PROJECTS:
         run_command([dotnet, "test", str(project), "--nologo"])
 
 
 def verify_skill_contract() -> None:
     quick_validate = locate_quick_validate()
     if not quick_validate:
-        print("Skipping quick_validate.py because the skill-creator validator was not found in this Codex install.")
+        print(
+            "Skipping quick_validate.py because the skill-creator validator was not found "
+            "(looked under the Codex and Claude skill homes)."
+        )
         return
     run_command([sys.executable, str(quick_validate), str(ROOT)])
 
 
 def locate_quick_validate() -> Path | None:
-    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
-    candidate = codex_home / "skills" / ".system" / "skill-creator" / "scripts" / "quick_validate.py"
-    return candidate if candidate.exists() else None
+    candidate_roots: list[Path] = []
+    for env_var in ("CODEX_HOME", "CLAUDE_CONFIG_DIR"):
+        value = os.environ.get(env_var)
+        if value:
+            candidate_roots.append(Path(value))
+    candidate_roots.append(Path.home() / ".codex")
+    candidate_roots.append(Path.home() / ".claude")
+    for root in candidate_roots:
+        candidate = root / "skills" / ".system" / "skill-creator" / "scripts" / "quick_validate.py"
+        if candidate.exists():
+            return candidate
+    return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Restructures PowerPlatform-Core from a single monolithic skill into a **modular, multi-agent plugin**, with a full robustness + cross-platform pass underneath.

One shared source now installs as **both a Claude Code plugin and an OpenAI Codex plugin**, the monolith is split into **11 focused skills**, and the live execution path runs on **Windows and macOS/Linux** (Windows behaviour unchanged).

## What's in here

**Plugin / multi-agent**
- `.claude-plugin/` + `.codex-plugin/` + `.agents/plugins/marketplace.json`   " install on either agent from one source; both manifests point at `skills/`.
- 11 skills under `skills/`: a `powerplatform-core` orchestrator (discovery, surface routing, mandatory live-mutation preflight) + 10 domain skills (schema, data, flows, plug-ins, PCF/web resources, code apps, solution-ALM, security, docs, connectors).
- Shared toolchain (`scripts/`, `tools/`, `references/`) stays at the plugin root, resolved via `$CLAUDE_PLUGIN_ROOT` / `$CODEX_PLUGIN_ROOT`. Root `SKILL.md` is now a thin plugin-aware pointer.

**Cross-platform**
- `CodexPowerPlatform.DataverseOps` multi-targets `net8.0` + `net8.0-windows`; the WAM broker is Windows-only (runtime-guarded), macOS/Linux use device-code sign-in. The WPF `AuthDialog` stays Windows-only and is skipped off-Windows in `verify_repo.py`.

**Robustness pass (verified)**
- 6 confirmed bugs fixed (security-role paging, requirement-spec step-types, `push_code_app` Windows exec resolution, FetchXML escaping, auth-dialog error, subprocess encoding) plus ~25 hardening fixes (timeouts, temp-file safety, FormXml DTD hardening, MSAL fallback, etc.), +8 regression tests.
- Note: the role `issytemgenerated` filter is the **real** (misspelled) Dataverse logical name   " verified against MS docs, left as-is.

**README + docs**
- README rewritten to a human-friendly, plugin-aware shape (badges, per-agent install, 11-skill table, quickstart, safety); maintainer detail moved to `docs/development.md`.

## Verification

`python verify_repo.py` is green: Python syntax, skill-structure + manifest checks, 83 unit tests, both .NET builds, and the .NET tests.

## Try it

- **Claude Code:** `/plugin marketplace add satriotsubasa/PowerPlatform-Core` then `/plugin install powerplatform-core@powerplatform-core` (post-merge; for a local checkout use `claude --plugin-dir "<path>"`).
- **Codex:** `codex plugin marketplace add satriotsubasa/PowerPlatform-Core` then `codex plugin add powerplatform-core` (verify the subcommand with `codex plugin --help`).

## Caveats

- The exact `codex plugin` subcommand can vary by version.
- A couple of working-contract-risky "improvements" were intentionally skipped (forcing camelCase on the C#/Python JSON boundary; re-parsing `pac` CLI output).
